### PR TITLE
chore: dotenv-vault 설정

### DIFF
--- a/client/.env.vault
+++ b/client/.env.vault
@@ -1,0 +1,12 @@
+#################################################################################
+#                                                                               #
+#          This file uniquely identifies your project in dotenv-vault.          #
+#               You SHOULD commit this file to source control.                  #
+#                                                                               #
+#                    Generated with 'npx dotenv-vault new'                      #
+#                                                                               #
+#                 Learn more at https://dotenv.org/env-vault                    #
+#                                                                               #
+#################################################################################
+
+DOTENV_VAULT=vlt_6f546b9027b83868825eb071a202d75a62a48c1b429093f53d64ed5ecb65ff17

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault

--- a/server/.env.vault
+++ b/server/.env.vault
@@ -1,0 +1,12 @@
+#################################################################################
+#                                                                               #
+#          This file uniquely identifies your project in dotenv-vault.          #
+#               You SHOULD commit this file to source control.                  #
+#                                                                               #
+#                    Generated with 'npx dotenv-vault new'                      #
+#                                                                               #
+#                 Learn more at https://dotenv.org/env-vault                    #
+#                                                                               #
+#################################################################################
+
+DOTENV_VAULT=vlt_f9daf648b14d5e2b073d0549cbd1076c795471540a28b8751064c94c27cd3bca

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,5 @@
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault


### PR DESCRIPTION
.gitignore 내용은 dotenv-vault 설정 시 자동으로 추가되었습니다.

`.gitignore` 설명:
- `.env.vault` 파일은 repo를 식별하기 때문에 커밋에 올라가야 합니다.
- `.env.me`는 사용자를 식별하기 때문에, 그리고 `.env`는 비밀이므로 커밋에서 제외되어야 합니다.

## 🤠 개요

resolves #8 

## 💫 설명

### 사용 방법

- `.env` 를 가지고 오려면 `npx dotenv-vault pull development` 커맨드를 실행해주세요.
- `.env`를 수정하고 변경사항을 푸시하려면 `npx dotenv-vault push development` 커맨드를 실행해주세요.

  🔴  커맨드 뒤에 `development`를 **꼭!** 잊지말고 작성해주세요. 그렇지 않으면 모든 환경에 대해 환경변수가 설정됩니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)

성공적으로 접근시 다음 화면을 볼 수 있습니다.

![screenshot](https://user-images.githubusercontent.com/89635107/201666575-25aef940-59ab-4ab4-9295-fcf5150a1a0f.png)

