### PR TITLE
Feat/#38-B: 워크스페이스 가져오는 API 테스트

### DIFF
--- a/server/apis/user/service.test.ts
+++ b/server/apis/user/service.test.ts
@@ -39,3 +39,5 @@ describe('getWorkspaces()', () => {
     );
   });
 });
+
+export {};

--- a/server/apis/user/service.test.ts
+++ b/server/apis/user/service.test.ts
@@ -1,0 +1,49 @@
+/**
+ * success -> userId === targetUserId
+ * fail -> userId !== targetUserId
+ */
+
+// userId 들을 넘기면 워크스페이스를 받는 것
+// userId를 넘겼을 때 성공적으로 워크스페이스를 받는 경우
+// 뭔가 userId가 이상해서 워크스페이스 못받는 경우
+const { getWorkspaces } = require('./service');
+const userModel = require('@apis/user/model');
+const workspaceModel = require('@apis/workspace/model');
+const { default: AuthorizationError } = require('@errors/authorization-error');
+const { default: CustomError } = require('@errors/index');
+
+jest.mock('@apis/user/model', () => {
+  return { findOne: jest.fn() };
+});
+
+jest.mock('@apis/workspace/model', () => {
+  return { find: jest.fn() };
+});
+
+describe('getWorkspaces()', () => {
+  const successfulUser = '';
+  const successfulWorkspaces: Object[] = [];
+
+  it('정상적인 유저 아이디를 받아서 성공적으로 워크스페이스를 가져온다.', async () => {
+    // arrange
+    userModel.findOne.mockResolvedValueOnce(successfulUser);
+    workspaceModel.find.mockResolvedValueOnce(successfulWorkspaces);
+
+    // act
+    const workspaces = await getWorkspaces('id', 'id');
+
+    // assert
+    expect(workspaces).toEqual(successfulWorkspaces);
+  });
+
+  it('비정상적인 유저 아이디를 받으면 에러를 던진다.', async () => {
+    // arrange
+    const user1 = 1;
+    const user2 = 2;
+
+    // act & assert
+    expect(() => getWorkspaces(user1, user2)).rejects.toThrow(
+      AuthorizationError,
+    );
+  });
+});

--- a/server/apis/user/service.test.ts
+++ b/server/apis/user/service.test.ts
@@ -1,8 +1,7 @@
 const { getWorkspaces } = require('./service');
 const userModel = require('@apis/user/model');
 const workspaceModel = require('@apis/workspace/model');
-const AuthorizationError = require('@errors/authorization-error');
-const CustomError = require('@errors/index');
+const { default: AuthorizationError } = require('@errors/authorization-error');
 
 jest.mock('@apis/user/model', () => {
   return { findOne: jest.fn() };

--- a/server/apis/user/service.test.ts
+++ b/server/apis/user/service.test.ts
@@ -1,16 +1,8 @@
-/**
- * success -> userId === targetUserId
- * fail -> userId !== targetUserId
- */
-
-// userId 들을 넘기면 워크스페이스를 받는 것
-// userId를 넘겼을 때 성공적으로 워크스페이스를 받는 경우
-// 뭔가 userId가 이상해서 워크스페이스 못받는 경우
 const { getWorkspaces } = require('./service');
 const userModel = require('@apis/user/model');
 const workspaceModel = require('@apis/workspace/model');
-const { default: AuthorizationError } = require('@errors/authorization-error');
-const { default: CustomError } = require('@errors/index');
+const AuthorizationError = require('@errors/authorization-error');
+const CustomError = require('@errors/index');
 
 jest.mock('@apis/user/model', () => {
   return { findOne: jest.fn() };

--- a/server/errors/authorization-error.ts
+++ b/server/errors/authorization-error.ts
@@ -1,8 +1,10 @@
 import CustomError from '.';
 import { UNAUTHORIZED } from '@constants/http-status';
 
-export default class AuthorizationError extends CustomError {
+class AuthorizationError extends CustomError {
   constructor(message = 'Unauthorized') {
     super(message, UNAUTHORIZED);
   }
 }
+
+export default AuthorizationError;

--- a/server/errors/index.ts
+++ b/server/errors/index.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_SERVER_ERROR } from '@constants/http-status';
 
-export default class CustomError extends Error {
+class CustomError extends Error {
   message!: string;
   status!: number;
 
@@ -14,3 +14,5 @@ export default class CustomError extends Error {
     this.status = status;
   }
 }
+
+export default CustomError;

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -2,11 +2,12 @@ module.exports = {
   preset: 'ts-jest', // to use typescript
   verbose: true,
   moduleNameMapper: {
-    "@apis/(.*)": "<rootDir>/apis/$1",
-    "@config": "<rootDir>/config",
-    "@constants/(.*)": "<rootDir>/constants/$1",
-    "@db": "<rootDir>/db",
-    "@middlewares/(.*)": "<rootDir>/middlewares/$1",
-    "@utils/(.*)": "<rootDir>/utils/$1"
-  }
-}
+    '@apis/(.*)': '<rootDir>/apis/$1',
+    '@config': '<rootDir>/config',
+    '@constants/(.*)': '<rootDir>/constants/$1',
+    '@db': '<rootDir>/db',
+    '@middlewares/(.*)': '<rootDir>/middlewares/$1',
+    '@utils/(.*)': '<rootDir>/utils/$1',
+    '@errors/(.*)': '<rootDir>/errors/$1',
+  },
+};


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->
- Resolve: #38

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

`toThrow(CustomError)`에서 `CustomError`을 인식하지 못하는 이슈가 있었어요.
```typescript
// 해결 전
export default class AuthorizationError extends CustomError {}
```
```typescript
// 해결 후
class AuthorizationError extends CustomError {}

export default AuthorizationError;
```
아마도 ESM과 CJS의 충돌같은데 이 부분은 제가 찾아볼게요.


## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)
<img width="583" alt="image" src="https://user-images.githubusercontent.com/65100540/201869287-9eeb1220-afff-4fdf-8488-5197c4f0883f.png">
