### PR TITLE
Feat/#26-S : 생성/참여 모달 UI 구현 & 모달 Open/Close 기능 구현

### DIFF
--- a/client/src/components/SelectModal/index.tsx
+++ b/client/src/components/SelectModal/index.tsx
@@ -1,0 +1,31 @@
+import cx from 'classnames';
+import Portal from 'src/components/Portal';
+
+import style from './style.module.scss';
+
+interface SelcetModalProps {
+  children: JSX.Element;
+  className?: string;
+}
+
+function SelcetModal({ children, className }: SelcetModalProps) {
+  const onClose = () => {
+    //
+  };
+
+  return (
+    <Portal>
+      <div
+        className={style.modal}
+        role="alertdialog"
+        aria-modal
+        aria-labelledby="modal"
+      >
+        <div className={cx(style.container, className)}>{children}</div>
+        <div className={style.dimmer} onClick={onClose} tabIndex={0}></div>
+      </div>
+    </Portal>
+  );
+}
+
+export default SelcetModal;

--- a/client/src/components/SelectModal/index.tsx
+++ b/client/src/components/SelectModal/index.tsx
@@ -6,11 +6,12 @@ import style from './style.module.scss';
 interface SelcetModalProps {
   children: JSX.Element;
   className?: string;
+  onClose: () => void;
 }
 
-function SelcetModal({ children, className }: SelcetModalProps) {
-  const onClose = () => {
-    //
+function SelcetModal({ children, className, onClose }: SelcetModalProps) {
+  const onClickCloseBtn = () => {
+    onClose();
   };
 
   return (
@@ -22,7 +23,11 @@ function SelcetModal({ children, className }: SelcetModalProps) {
         aria-labelledby="modal"
       >
         <div className={cx(style.container, className)}>{children}</div>
-        <div className={style.dimmer} onClick={onClose} tabIndex={0}></div>
+        <div
+          className={style.dimmer}
+          onClick={onClickCloseBtn}
+          tabIndex={0}
+        ></div>
       </div>
     </Portal>
   );

--- a/client/src/components/SelectModal/style.module.scss
+++ b/client/src/components/SelectModal/style.module.scss
@@ -1,0 +1,33 @@
+@import 'style/color.scss';
+
+.modal {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  .container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    width: fit-content;
+    height: fit-content;
+
+    border-radius: 10px;
+    background-color: $primary-100;
+    padding: 20px;
+    color: $white;
+    font-size: 14px;
+    margin: auto;
+
+    .dimmer {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+  }
+}

--- a/client/src/components/SelectModal/style.module.scss
+++ b/client/src/components/SelectModal/style.module.scss
@@ -1,6 +1,10 @@
 @import 'style/color.scss';
 
 .modal {
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: fixed;
   top: 0;
   bottom: 0;
@@ -21,13 +25,13 @@
     color: $white;
     font-size: 14px;
     margin: auto;
-
-    .dimmer {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-    }
+  }
+  .dimmer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $modalBackground;
   }
 }

--- a/client/src/components/WorkspaceList/AddButton.tsx
+++ b/client/src/components/WorkspaceList/AddButton.tsx
@@ -1,13 +1,21 @@
-import { MdAdd } from "@react-icons/all-files/md/MdAdd";
-import React from "react";
+import { MdAdd } from '@react-icons/all-files/md/MdAdd';
+import React from 'react';
 
-import style from "./style.module.scss";
+import style from './style.module.scss';
 
-function AddButton() {
+interface AddButtonProps {
+  onClick: () => void;
+}
+
+function AddButton({ onClick }: AddButtonProps) {
+  const onClickBtn = () => {
+    onClick();
+  };
+
   return (
-    <div className={style.button}>
+    <button className={style.button} onClick={onClickBtn}>
       <MdAdd color="white" size={20} />
-    </div>
+    </button>
   );
 }
 

--- a/client/src/components/WorkspaceList/WorkspaceThumbnailItem.tsx
+++ b/client/src/components/WorkspaceList/WorkspaceThumbnailItem.tsx
@@ -1,6 +1,4 @@
-import React from "react";
-
-import style from "./style.module.scss";
+import style from './style.module.scss';
 
 interface WorkspaceThumbnailItemProps {
   name: string;

--- a/client/src/components/WorkspaceList/WorkspaceThumbnailItem.tsx
+++ b/client/src/components/WorkspaceList/WorkspaceThumbnailItem.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import style from './style.module.scss';
 
 interface WorkspaceThumbnailItemProps {
@@ -19,4 +21,4 @@ function WorkspaceThumbnailItem({ name }: WorkspaceThumbnailItemProps) {
   );
 }
 
-export default WorkspaceThumbnailItem;
+export default memo(WorkspaceThumbnailItem);

--- a/client/src/components/WorkspaceList/WorkspaceThumbnailList.tsx
+++ b/client/src/components/WorkspaceList/WorkspaceThumbnailList.tsx
@@ -1,13 +1,11 @@
-import React from "react";
-
-import style from "./style.module.scss";
-import WorkspaceThumbnailItem from "./WorkspaceThumbnailItem";
+import style from './style.module.scss';
+import WorkspaceThumbnailItem from './WorkspaceThumbnailItem';
 
 const workspaces = [
-  { id: 1, name: "왭" },
-  { id: 2, name: "네이버" },
-  { id: 3, name: "카카오" },
-  { id: 4, name: "토스" },
+  { id: 1, name: '왭' },
+  { id: 2, name: '네이버' },
+  { id: 3, name: '카카오' },
+  { id: 4, name: '토스' },
 ];
 
 function WorkspaceThumbnailList() {

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import { memo } from 'react';
 
-import AddButton from "./AddButton";
-import style from "./style.module.scss";
-import WorkspaceThumbnaliList from "./WorkspaceThumbnailList";
+import AddButton from './AddButton';
+import style from './style.module.scss';
+import WorkspaceThumbnaliList from './WorkspaceThumbnailList';
 
 function WorkspaceList() {
   return (
@@ -13,4 +13,4 @@ function WorkspaceList() {
   );
 }
 
-export default WorkspaceList;
+export default memo(WorkspaceList);

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -4,11 +4,15 @@ import AddButton from './AddButton';
 import style from './style.module.scss';
 import WorkspaceThumbnaliList from './WorkspaceThumbnailList';
 
-function WorkspaceList() {
+interface WorkspaceListProps {
+  onSelectModalOpen: () => void;
+}
+
+function WorkspaceList({ onSelectModalOpen }: WorkspaceListProps) {
   return (
     <div className={style.workspace__container}>
       <WorkspaceThumbnaliList />
-      <AddButton />
+      <AddButton onClick={onSelectModalOpen} />
     </div>
   );
 }

--- a/client/src/components/WorkspaceModal/index.tsx
+++ b/client/src/components/WorkspaceModal/index.tsx
@@ -8,6 +8,7 @@ interface WorkspaceModalProps {
   btnText: string;
   inputValue: string;
   onChange?: (value: string) => void;
+  onClose: () => void;
 }
 
 function WorkspaceModal({
@@ -16,13 +17,14 @@ function WorkspaceModal({
   btnText,
   inputValue,
   onChange,
+  onClose,
 }: WorkspaceModalProps) {
   const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (onChange) onChange(e.target.value);
   };
 
   return (
-    <Modal title={title}>
+    <Modal title={title} onClose={onClose}>
       <>
         <span className={style.text}>{text}</span>
         <input className={style.input} type="text" onChange={onInput} />

--- a/client/src/components/WorkspaceModal/index.tsx
+++ b/client/src/components/WorkspaceModal/index.tsx
@@ -1,0 +1,35 @@
+import Button from '../common/Button';
+import Modal from '../common/Modal';
+import style from './style.module.scss';
+
+interface WorkspaceModalProps {
+  title: string;
+  text: string;
+  btnText: string;
+  inputValue: string;
+  onChange?: (value: string) => void;
+}
+
+function WorkspaceModal({
+  title,
+  text,
+  btnText,
+  inputValue,
+  onChange,
+}: WorkspaceModalProps) {
+  const onInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (onChange) onChange(e.target.value);
+  };
+
+  return (
+    <Modal title={title}>
+      <>
+        <span className={style.text}>{text}</span>
+        <input className={style.input} type="text" onChange={onInput} />
+        <Button text={btnText} isDisable={!inputValue.length} />
+      </>
+    </Modal>
+  );
+}
+
+export default WorkspaceModal;

--- a/client/src/components/WorkspaceModal/style.module.scss
+++ b/client/src/components/WorkspaceModal/style.module.scss
@@ -1,0 +1,13 @@
+@import 'style/color.scss';
+
+.text {
+  font-size: 14px;
+}
+.input {
+  width: calc(100% - 6rem);
+  border: 1px solid $gray-100;
+  border-radius: 10px;
+  padding: 10px;
+  font-size: 14px;
+  margin: 15px 0;
+}

--- a/client/src/components/common/Button/index.tsx
+++ b/client/src/components/common/Button/index.tsx
@@ -1,18 +1,31 @@
-import cx from "classnames";
+import classNames from 'classnames/bind';
 
-import style from "./style.module.scss";
+import style from './style.module.scss';
+
+const cx = classNames.bind(style);
 
 interface ButtonProps {
   text: string;
   icon?: JSX.Element;
   className?: string;
+  isDisable?: boolean;
+  color?: string;
 }
 
-function Button({ text, icon, className }: ButtonProps) {
+function Button({
+  text,
+  icon,
+  className,
+  isDisable = false,
+  color,
+}: ButtonProps) {
   return (
-    <div className={cx(style.button, className)}>
+    <div
+      className={cx(style.button, className, { disable: isDisable })}
+      style={{ backgroundColor: color }}
+    >
       {icon}
-      <button>{text}</button>
+      <button disabled={isDisable}>{text}</button>
     </div>
   );
 }

--- a/client/src/components/common/Button/style.module.scss
+++ b/client/src/components/common/Button/style.module.scss
@@ -1,4 +1,4 @@
-@import "style/color.scss";
+@import 'style/color.scss';
 
 .button {
   width: fit-content;
@@ -14,4 +14,8 @@
     padding: 10px;
     font-weight: 700;
   }
+}
+
+.disable {
+  background-color: $gray-300;
 }

--- a/client/src/components/common/Modal/index.tsx
+++ b/client/src/components/common/Modal/index.tsx
@@ -1,7 +1,7 @@
-import Portal from "src/components/Portal";
-import style from "./style.module.scss";
-import { MdClose } from "@react-icons/all-files/md/MdClose";
-import cx from "classnames";
+import { MdClose } from '@react-icons/all-files/md/MdClose';
+import Portal from 'src/components/Portal';
+
+import style from './style.module.scss';
 
 interface ModalProps {
   title?: string;
@@ -10,13 +10,10 @@ interface ModalProps {
   className?: string;
 }
 
-function Modal({
-  title,
-  isHaveCloseBtn = true,
-  children,
-  className,
-}: ModalProps) {
-  const onClickDimmer = () => {};
+function Modal({ title, children }: ModalProps) {
+  const onClose = () => {
+    //
+  };
 
   return (
     <Portal>
@@ -26,25 +23,18 @@ function Modal({
         aria-modal
         aria-labelledby="modal"
       >
-        <div className={cx(style.container, className)}>
-          {(title || isHaveCloseBtn) && (
-            <div className={style.header}>
-              {title && <h2>{title}</h2>}
-              {isHaveCloseBtn && (
-                <span>
-                  <MdClose />
-                </span>
-              )}
-            </div>
-          )}
-
-          {children}
+        <div className={style.dimmer} onClick={onClose} tabIndex={0} />
+        <div className={style['out-container']}>
+          <div className={style.header} id="modal-heading">
+            <h2 className={style.title}>{title}</h2>
+            <button className={style['close-modal']}>
+              <MdClose size={20} color={'white'} />
+            </button>
+          </div>
+          <div className={style['inner-container']} role="document">
+            {children}
+          </div>
         </div>
-        <div
-          className={style.dimmer}
-          onClick={onClickDimmer}
-          tabIndex={0}
-        ></div>
       </div>
     </Portal>
   );

--- a/client/src/components/common/Modal/index.tsx
+++ b/client/src/components/common/Modal/index.tsx
@@ -5,14 +5,13 @@ import style from './style.module.scss';
 
 interface ModalProps {
   title?: string;
-  isHaveCloseBtn?: boolean;
   children: JSX.Element;
-  className?: string;
+  onClose: () => void;
 }
 
-function Modal({ title, children }: ModalProps) {
-  const onClose = () => {
-    //
+function Modal({ title, children, onClose }: ModalProps) {
+  const onClickCloseBtn = () => {
+    onClose();
   };
 
   return (
@@ -23,11 +22,11 @@ function Modal({ title, children }: ModalProps) {
         aria-modal
         aria-labelledby="modal"
       >
-        <div className={style.dimmer} onClick={onClose} tabIndex={0} />
+        <div className={style.dimmer} onClick={onClickCloseBtn} tabIndex={0} />
         <div className={style['out-container']}>
           <div className={style.header} id="modal-heading">
             <h2 className={style.title}>{title}</h2>
-            <button className={style['close-modal']}>
+            <button className={style['close-modal']} onClick={onClickCloseBtn}>
               <MdClose size={20} color={'white'} />
             </button>
           </div>

--- a/client/src/components/common/Modal/style.module.scss
+++ b/client/src/components/common/Modal/style.module.scss
@@ -1,38 +1,57 @@
-@import "style/color.scss";
+@import 'style/color.scss';
 
 .modal {
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
 
-  .container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  .dimmer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: $modalBackground;
+  }
 
-    width: fit-content;
-    height: fit-content;
-
+  .out-container {
+    z-index: 100;
+    min-width: 400px;
+    overflow-y: auto;
     border-radius: 10px;
-    background-color: $primary-100;
-    padding: 20px;
-    color: $white;
-    font-size: 14px;
-    margin: auto;
+    background-color: $white;
 
     .header {
-      h2 {
-        font-size: 16px;
+      position: sticky;
+      display: flex;
+      align-items: center;
+      padding: 20px;
+      background-color: $primary-100;
+      color: $white;
+
+      .title {
+        width: 100%;
+        text-align: center;
+        font-size: 18px;
+        font-weight: 700;
+      }
+      .close-modal {
+        position: absolute;
+        right: 10px;
       }
     }
-    .dimmer {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
+
+    .inner-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 30px 20px;
     }
   }
 }

--- a/client/src/constants/workspace.ts
+++ b/client/src/constants/workspace.ts
@@ -1,0 +1,23 @@
+export const MENUS = [
+  { id: 1, text: '생성하기' },
+  { id: 2, text: '참여하기' },
+];
+
+export const MODAL_MENUS = [
+  {
+    id: 1,
+    props: {
+      title: '워크스페이스 생성',
+      text: '워크스페이스 이름을 입력해주세요.',
+      btnText: '생성하기',
+    },
+  },
+  {
+    id: 2,
+    props: {
+      title: '워크스페이스 참여',
+      text: '워크스페이스 코드를 입력해주세요.',
+      btnText: '참여하기',
+    },
+  },
+];

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -1,17 +1,47 @@
-import style from "./style.module.scss";
-import WorkspaceList from "src/components/WorkspaceList";
-import Modal from "src/components/common/Modal";
+import { useState } from 'react';
+import SelcetModal from 'src/components/SelectModal';
+import WorkspaceList from 'src/components/WorkspaceList';
+import WorkspaceModal from 'src/components/WorkspaceModal';
+import { MENUS, MODAL_MENUS } from 'src/constants/workspace';
+
+import style from './style.module.scss';
 
 function WorkspacePage() {
+  const [clickedMenuId, setClickedMenuId] = useState(0);
+  const [inputValue, setInputValue] = useState('');
+
+  const onInput = (value: string) => {
+    setInputValue(value);
+  };
+
+  const onClickMenu = (id: number) => {
+    setClickedMenuId(id);
+  };
+
   return (
     <div className={style.container}>
       <WorkspaceList />
-      <Modal className={style["select-modal"]} isHaveCloseBtn={false}>
-        <ul className={style["menu-list"]}>
-          <li>생성하기</li>
-          <li>참여하기</li>
+      <SelcetModal className={style['select-modal']}>
+        <ul className={style['menu-list']}>
+          {MENUS.map(({ id, text }) => (
+            <li key={id} onClick={() => onClickMenu(id)}>
+              {text}
+            </li>
+          ))}
         </ul>
-      </Modal>
+      </SelcetModal>
+
+      {MODAL_MENUS.map(({ id, props: { title, text, btnText } }) => {
+        if (id === clickedMenuId)
+          return (
+            <WorkspaceModal
+              key={id}
+              {...{ title, text, btnText }}
+              inputValue={inputValue}
+              onChange={onInput}
+            />
+          );
+      })}
     </div>
   );
 }

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -7,6 +7,7 @@ import { MENUS, MODAL_MENUS } from 'src/constants/workspace';
 import style from './style.module.scss';
 
 function WorkspacePage() {
+  const [isOpenSelectModal, setIsOpenSelectModal] = useState(false);
   const [clickedMenuId, setClickedMenuId] = useState(0);
   const [inputValue, setInputValue] = useState('');
 
@@ -20,16 +21,21 @@ function WorkspacePage() {
 
   return (
     <div className={style.container}>
-      <WorkspaceList />
-      <SelcetModal className={style['select-modal']}>
-        <ul className={style['menu-list']}>
-          {MENUS.map(({ id, text }) => (
-            <li key={id} onClick={() => onClickMenu(id)}>
-              {text}
-            </li>
-          ))}
-        </ul>
-      </SelcetModal>
+      <WorkspaceList onSelectModalOpen={() => setIsOpenSelectModal(true)} />
+      {isOpenSelectModal && (
+        <SelcetModal
+          className={style['select-modal']}
+          onClose={() => setIsOpenSelectModal(false)}
+        >
+          <ul className={style['menu-list']}>
+            {MENUS.map(({ id, text }) => (
+              <li key={id} onClick={() => onClickMenu(id)}>
+                {text}
+              </li>
+            ))}
+          </ul>
+        </SelcetModal>
+      )}
 
       {MODAL_MENUS.map(({ id, props: { title, text, btnText } }) => {
         if (id === clickedMenuId)

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -39,6 +39,7 @@ function WorkspacePage() {
               {...{ title, text, btnText }}
               inputValue={inputValue}
               onChange={onInput}
+              onClose={() => setClickedMenuId(0)}
             />
           );
       })}

--- a/client/src/pages/Workspace/style.module.scss
+++ b/client/src/pages/Workspace/style.module.scss
@@ -1,13 +1,15 @@
-@import "style/color.scss";
+@import 'style/color.scss';
 
 .container {
   position: relative;
 }
 
 .select-modal {
+  z-index: 2;
   position: absolute;
   top: 20em;
   left: 50px;
+  box-shadow: 1px 1px 3px $gray-300;
 
   .menu-list {
     li {

--- a/client/src/styles/color.scss
+++ b/client/src/styles/color.scss
@@ -8,3 +8,4 @@ $red: #cc3b3b;
 $green: #36ba2b;
 $highlight-100: #59c3ff;
 $highlight-200: #1264a3;
+$modalBackground: #29292958;


### PR DESCRIPTION
## 🤠 개요

- resolve #26 

## 💫 설명
- 워크스페이스 추가버튼 눌렀을 때 나오는 선택 모달(`SelectModal`)과 생성/참여/생성완료 모달(`Modal`)을 다른 컴포넌트로 구분했어요
  - 모달 헤더의 조건문이 전부 삭제돼서 헤더 분리를 안해도 괜찮을 거 같은데 어떤가요?
- SelectModal, Modal 컴포넌트에 모두 open/close 기능을 적용시켰어요
- 공통 컴포넌트인 Button에 disable, color 속성이 추가됐어요 -> Input value 값이 있을 경우를 조건문으로 넣어주면 disable/able 조절돼요
  - 기능 사용하실 때 onClick 함수를 Props에 추가하면 될 거 같애요
- `AddButton` 컴포넌트가 div 태그인데 button이 적절할 거 같아서 변경했어요!

- `feat/#23-S` 브랜치에서 모달을 만들어둬서 여기서 브랜치를 땄어요

## 🌜 고민거리 (Optional)

- style 이 매우 마음에 안들지만 스타일 예쁜게 중요한게 아니니까 그냥 할게요 ..^^ 스타일에 너무 신경쓰느라 애먹었어요 ..
- UI 만들기 그만 하고 싶어졌어요

## 📷 스크린샷 (Optional)

![화면 기록 2022-11-15 오후 5 49 30](https://user-images.githubusercontent.com/63364990/201873734-37d6d551-5a81-43e8-90eb-179accb4dbd1.gif)
