### PR TITLE
Feat/#20-B: 워크스페이스 리스트 API, UI 연동

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "classnames": "^2.3.2",
     "@react-icons/all-files": "^4.1.0",
+    "axios": "^1.1.3",
+    "classnames": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { LoginPage, WorkspacePage } from "./pages";
-import "style/reset.scss";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+import { LoginPage, WorkspacePage } from './pages';
+import 'style/reset.scss';
 
 function App() {
   return (

--- a/client/src/apis/http.ts
+++ b/client/src/apis/http.ts
@@ -2,6 +2,6 @@ import axios from 'axios';
 
 const SERVER_URL = 'http://localhost:8080';
 
-export const baseRequest = axios.create({
+export const http = axios.create({
   baseURL: SERVER_URL,
 });

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,6 +1,6 @@
 import { baseRequest } from './util';
 
-export const getWorkspacesAPI = async (userId: number) => {
+export const getWorkspaces = async (userId: number) => {
   try {
     const { data } = await baseRequest.get(`/user/${userId}/workspace`);
 

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,11 +1,11 @@
-import { baseRequest } from './util';
+import { http } from './http';
 
 export const getWorkspaces = async (userId: number) => {
   try {
-    const { data } = await baseRequest.get(`/user/${userId}/workspace`);
+    const { data } = await http.get(`/user/${userId}/workspace`);
 
     return data;
   } catch (e) {
-    console.log(e);
+    return;
   }
 };

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,0 +1,11 @@
+import { baseRequest } from './util';
+
+export const getWorkspacesAPI = async (userId: number) => {
+  try {
+    const { data } = await baseRequest.get(`/user/${userId}/workspace`);
+
+    return data;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/client/src/apis/util.ts
+++ b/client/src/apis/util.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const SERVER_URL = 'http://localhost:8080';
+
+export const baseRequest = axios.create({
+  baseURL: SERVER_URL,
+});

--- a/client/src/components/WorkspaceList/WorkspaceThumbnailList.tsx
+++ b/client/src/components/WorkspaceList/WorkspaceThumbnailList.tsx
@@ -1,14 +1,13 @@
+import { Workspace } from 'src/types/workspace';
+
 import style from './style.module.scss';
 import WorkspaceThumbnailItem from './WorkspaceThumbnailItem';
 
-const workspaces = [
-  { id: 1, name: '왭' },
-  { id: 2, name: '네이버' },
-  { id: 3, name: '카카오' },
-  { id: 4, name: '토스' },
-];
+interface WorkspaceThumbnailListProps {
+  workspaces: Workspace[];
+}
 
-function WorkspaceThumbnailList() {
+function WorkspaceThumbnailList({ workspaces }: WorkspaceThumbnailListProps) {
   return (
     <ul className={style.thumbnail__list}>
       {workspaces.map((workspace) => (

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -1,4 +1,6 @@
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
+import { getWorkspacesAPI } from 'src/apis/user';
+import { Workspace } from 'src/types/workspace';
 
 import AddButton from './AddButton';
 import style from './style.module.scss';
@@ -9,9 +11,24 @@ interface WorkspaceListProps {
 }
 
 function WorkspaceList({ onSelectModalOpen }: WorkspaceListProps) {
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  /**
+   * 나중에 login하고 context생기면 바꿔 끼우면 돼요.
+   */
+  const userId = 63814960;
+
+  const getWorkspaces = async (userId: number) => {
+    const { workspaces } = await getWorkspacesAPI(userId);
+    setWorkspaces(workspaces);
+  };
+
+  useEffect(() => {
+    getWorkspaces(userId);
+  }, []);
+
   return (
     <div className={style.workspace__container}>
-      <WorkspaceThumbnaliList />
+      <WorkspaceThumbnaliList workspaces={workspaces} />
       <AddButton onClick={onSelectModalOpen} />
     </div>
   );

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from 'react';
-import { getWorkspacesAPI } from 'src/apis/user';
+import { getWorkspaces } from 'src/apis/user';
 import { Workspace } from 'src/types/workspace';
 
 import AddButton from './AddButton';
@@ -17,13 +17,13 @@ function WorkspaceList({ onSelectModalOpen }: WorkspaceListProps) {
    */
   const userId = 63814960;
 
-  const getWorkspaces = async (userId: number) => {
-    const { workspaces } = await getWorkspacesAPI(userId);
+  const updateWorkspaces = async (userId: number) => {
+    const { workspaces } = await getWorkspaces(userId);
     setWorkspaces(workspaces);
   };
 
   useEffect(() => {
-    getWorkspaces(userId);
+    updateWorkspaces(userId);
   }, []);
 
   return (

--- a/client/src/types/workspace.ts
+++ b/client/src/types/workspace.ts
@@ -1,0 +1,4 @@
+export interface Workspace {
+  id: number;
+  name: string;
+}

--- a/server/apis/user/controller.ts
+++ b/server/apis/user/controller.ts
@@ -17,6 +17,8 @@ router.get(
       userId,
     );
 
+    res.setHeader('Access-Control-Allow-origin', '*');
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
     res.send({ workspaces });
   }),
 );


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #20 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

axios를 사용했어요.
- 찾아보니까 axios에 instance를 미리 만들 수 있더라구요.
  ```ts
  const instance = axios.create({
    baseURL: 'https://some-domain.com/api/',
    headers: { 'X-Custom-Header': 'foobar' },
    timeout: 1000,
  });
  ```
- 이거 아니더라도 server에서 axios를 사용해봤는데 fetch와는 다르게 `await response.json()`등의 절차가 생략되어서 생산성이 향상될거라고 생각해서 client에도 적용했어요.

<br>

workspaces를 props로 전달하고 있어요.

- user의 workspace 리스트에 대한 정보를 `WorkspaceList`에서만 사용할 것 같아서 `WorkspaceList` 컴포넌트가 mount될 때 api를 호출해서 workspaces들을 `props`로 내려줘서 렌더링할 수 있게 했어요.

- 저희 기획대로면 이 상태는 이 컴포넌트 외에선 사용될 곳이 없을 것 같아서 따로 context나 전역 상태로 빼는건 너무 오버엔지니어링이라고 판단해서 props로 처리했어요.

- 이 부분에 대해서 다른 의견 있으신 분 계시면 알려주세요!

<br>

연동할 때 브라우저에서 로그인을 할 수 없어서 일단 controller를 이렇게 변경하고 테스트해봤어요.
```typescript
router.get(
  // '/:id/workspace',
  jwtAuthenticator,
  asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
    // const { id: userId } = req.user;
    const { id: targetUserId } = req.params;
    const userId = targetuserId;
   ...
```

<br>

CORS를 해결하기 위해서 헤더를 달아줬어요.
```typescript
res.setHeader('Access-Control-Allow-origin', '*');
res.setHeader('Access-Control-Allow-Credentials', 'true');
```
- CORS 라이브러리나 proxy 설정같은건 따로 얘기해보고 적용하는게 좋을 것 같아서 일단 헤더로 처리해뒀어


<br>

에러 핸들링은 조금 더 공부해보려고 해요. 공부해서 기술 공유때 공유할게요 :) 

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->


## 📷 스크린샷 (Optional)

- 제 아이디로 test했는데 참여중인 workspace가 없어서 아무것도 안떠요.

<img src="https://user-images.githubusercontent.com/65100540/201928499-6a30ae1b-71b8-4409-8e26-5f0e0ec104b2.png" height=500>
