### PR TITLE
Chore/#46-C: dotenv-vault pull npm 커맨드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "postinstall": "husky install",
     "lint-staged": "lint-staged",
+    "env": "npm run dotenv-pull",
     "dotenv-pull": "npm run dotenv-pull:client && npm run dotenv-pull:server",
     "dotenv-pull:client": "echo For client... && cd client && npx dotenv-vault pull development",
     "dotenv-pull:server": "echo For server... && cd server && npx dotenv-vault pull development"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "repository": "https://github.com/boostcampwm-2022/web27-Wabinar.git",
   "scripts": {
     "postinstall": "husky install",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "dotenv-pull": "npm run dotenv-pull:client && npm run dotenv-pull:server",
+    "dotenv-pull:client": "echo For client... && cd client && npx dotenv-vault pull development",
+    "dotenv-pull:server": "echo For server... && cd server && npx dotenv-vault pull development"
   },
   "lint-staged": {
     "client/**/*.{ts,tsx}": [


### PR DESCRIPTION
## 🤠 개요

- resolves #46

두 디렉토리에 직접 들어가지 않고 하나의 커맨드로 pull 하도록 커맨드 추가

## 💫 설명

이제 바깥 디렉토리에서 `npm run dotenv-pull` 실행하면 `client`, `server` 디렉토리에서 자동으로 `pull` 합니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)

![1](https://user-images.githubusercontent.com/89635107/202074346-3b67e62d-fab0-4e70-89e3-1723915dd4c6.gif)
