### PR TITLE
Fix/#50-B: user 초기값이 없을 때 렌더링 되는 문제 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,11 +2,11 @@ import { useState, useEffect } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { getAuth } from 'src/apis/auth';
 import UserContext, { User } from 'src/contexts/user';
-import { LoginPage, OAuthPage, WorkspacePage } from 'src/pages';
+import { LoadingPage, LoginPage, OAuthPage, WorkspacePage } from 'src/pages';
 import 'styles/reset.scss';
 
 function App() {
-  const [user, setUser] = useState<User>({ id: -1, name: '', avatarUrl: '' });
+  const [user, setUser] = useState<User | null>(null);
   const navigate = useNavigate();
 
   const autoLogin = async () => {
@@ -22,7 +22,7 @@ function App() {
     autoLogin();
   }, []);
 
-  return (
+  return user ? (
     <UserContext.Provider value={{ user, setUser }}>
       <Routes>
         <Route path="/" element={<LoginPage />} />
@@ -30,6 +30,8 @@ function App() {
         <Route path="/workspace" element={<WorkspacePage />} />
       </Routes>
     </UserContext.Provider>
+  ) : (
+    <LoadingPage />
   );
 }
 

--- a/client/src/contexts/user.ts
+++ b/client/src/contexts/user.ts
@@ -7,8 +7,8 @@ export interface User {
 }
 
 interface IUserContext {
-  user?: User;
-  setUser: Dispatch<SetStateAction<User>>;
+  user: User;
+  setUser: Dispatch<SetStateAction<User | null>>;
 }
 
 const UserContext = createContext<IUserContext | null>(null);

--- a/client/src/pages/Loading/index.tsx
+++ b/client/src/pages/Loading/index.tsx
@@ -1,0 +1,14 @@
+import cx from 'classnames';
+import Loader from 'components/common/Loader';
+
+import style from './style.module.scss';
+
+function LoadingPage() {
+  return (
+    <div className={cx(style.container)}>
+      <Loader size={100} />
+    </div>
+  );
+}
+
+export default LoadingPage;

--- a/client/src/pages/Loading/style.module.scss
+++ b/client/src/pages/Loading/style.module.scss
@@ -1,0 +1,14 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+}
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+}

--- a/client/src/pages/Loading/style.module.scss
+++ b/client/src/pages/Loading/style.module.scss
@@ -5,10 +5,3 @@
   width: 100vw;
   height: 100vh;
 }
-.container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100vw;
-  height: 100vh;
-}

--- a/client/src/pages/OAuth/index.tsx
+++ b/client/src/pages/OAuth/index.tsx
@@ -1,11 +1,8 @@
-import cx from 'classnames';
-import Loader from 'components/common/Loader';
 import { useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { postAuthLogin } from 'src/apis/auth';
 import UserContext from 'src/contexts/user';
-
-import style from './style.module.scss';
+import LoadingPage from 'src/pages/Loading';
 
 function OAuthPage() {
   const userContext = useContext(UserContext);
@@ -13,11 +10,7 @@ function OAuthPage() {
   if (userContext === null) {
     console.log('유저 컨텍스트를 찾을 수 없습니다.');
 
-    return (
-      <div className={cx(style.container)}>
-        <Loader size={100} />
-      </div>
-    );
+    return <LoadingPage />;
   }
 
   const location = useLocation();
@@ -47,11 +40,7 @@ function OAuthPage() {
     login(code);
   }, []);
 
-  return (
-    <div className={cx(style.container)}>
-      <Loader size={100} />
-    </div>
-  );
+  return <LoadingPage />;
 }
 
 export default OAuthPage;

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,3 +1,4 @@
+export { default as LoadingPage } from './Loading';
 export { default as WorkspacePage } from './Workspace';
 export { default as LoginPage } from './Login';
 export { default as OAuthPage } from './OAuth';


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #54 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

user의 초기값이 없을 때 `{id: -1, name: "", ... }` App이 렌더링되면 WorkspaceList에서 `GET /user/-1/workspace` 요청을 하게 돼요.
그래서 user 정보를 받아왔을때만 App을 렌더링하게 했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)