### PR TITLE
Chore/#57-K: API 파라미터 타입 정의

### DIFF
--- a/client/src/apis/auth.ts
+++ b/client/src/apis/auth.ts
@@ -1,3 +1,5 @@
+import { PostLoginParams } from 'params/auth';
+
 import { http } from './http';
 import { OK, CREATED } from './http-status';
 
@@ -9,7 +11,7 @@ export const getAuth = async () => {
   return res.data;
 };
 
-export const postAuthLogin = async (code: string) => {
+export const postAuthLogin = async ({ code }: PostLoginParams) => {
   const res = await http.post(`/auth/login`, { code });
 
   if (res.status !== CREATED) throw new Error();

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,8 +1,10 @@
+import { GetWorkspaceParams } from 'params/user';
+
 import { http } from './http';
 import { OK } from './http-status';
 
-export const getWorkspaces = async (userId: number) => {
-  const res = await http.get(`/user/${userId}/workspace`);
+export const getWorkspaces = async ({ id }: GetWorkspaceParams) => {
+  const res = await http.get(`/user/${id}/workspace`);
 
   if (res.status !== OK) throw new Error();
 

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -16,7 +16,7 @@ function WorkspaceList({ onSelectModalOpen }: WorkspaceListProps) {
   const userContext = useContext(UserContext);
 
   const updateWorkspaces = async (userId: number) => {
-    const { workspaces } = await getWorkspaces(userId);
+    const { workspaces } = await getWorkspaces({ id: userId });
     setWorkspaces(workspaces);
   };
 

--- a/client/src/pages/OAuth/index.tsx
+++ b/client/src/pages/OAuth/index.tsx
@@ -18,7 +18,7 @@ function OAuthPage() {
 
   const login = async (code: string) => {
     try {
-      const authorizedUser = await postAuthLogin(code);
+      const authorizedUser = await postAuthLogin({ code });
 
       userContext.setUser(authorizedUser);
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,7 +5,8 @@
       "src/*": ["./src/*"],
       "components/*": ["./src/components/*"],
       "config": ["./src/config"],
-      "styles/*": ["./src/styles/*"]
+      "styles/*": ["./src/styles/*"],
+      "params/*": ["../types/params/*"]
     },
     "target": "ESNext",
     "useDefineForClassFields": true,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       },
       { find: 'config', replacement: resolve(__dirname, './src/config') },
       { find: 'styles', replacement: resolve(__dirname, './src/styles') },
+      { find: 'params', replacement: resolve(__dirname, '../types/params') },
     ],
   },
 });

--- a/server/apis/auth/controller.ts
+++ b/server/apis/auth/controller.ts
@@ -3,7 +3,7 @@ import asyncWrapper from '@utils/async-wrapper';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
 import * as authService from './service';
 import { OK, CREATED } from '@constants/http-status';
-import { postLoginParams } from '@params/auth';
+import { PostLoginParams } from '@params/auth';
 
 interface CookieOptions {
   httpOnly: boolean;
@@ -24,7 +24,7 @@ router.get(
 
 router.post(
   '/login',
-  asyncWrapper(async (req: Request<postLoginParams>, res: Response) => {
+  asyncWrapper(async (req: Request<PostLoginParams>, res: Response) => {
     const { code } = req.body;
 
     const { user, loginToken, refreshToken } = await authService.login(code);

--- a/server/apis/auth/controller.ts
+++ b/server/apis/auth/controller.ts
@@ -3,6 +3,7 @@ import asyncWrapper from '@utils/async-wrapper';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
 import * as authService from './service';
 import { OK, CREATED } from '@constants/http-status';
+import { postLoginParams } from '@params/auth';
 
 interface CookieOptions {
   httpOnly: boolean;
@@ -23,7 +24,7 @@ router.get(
 
 router.post(
   '/login',
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request<postLoginParams>, res: Response) => {
     const { code } = req.body;
 
     const { user, loginToken, refreshToken } = await authService.login(code);

--- a/server/apis/auth/service.ts
+++ b/server/apis/auth/service.ts
@@ -17,7 +17,7 @@ export const login = async (code: string) => {
     avatar_url: avatarUrl,
   } = await getGithubUser(accessToken, tokenType);
 
-  const isSignedUp = userModel.exists({ id });
+  const isSignedUp = await userModel.exists({ id });
 
   if (!isSignedUp) {
     await userModel.create({

--- a/server/apis/user/controller.ts
+++ b/server/apis/user/controller.ts
@@ -2,14 +2,14 @@ import express, { Request, Response } from 'express';
 import asyncWrapper from '@utils/async-wrapper';
 import * as userService from './service';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
-import { getWorkspaceParams } from '@params/user';
+import { GetWorkspaceParams } from '@params/user';
 
 const router = express.Router();
 
 router.get(
   '/:id/workspace',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request<getWorkspaceParams>, res: Response) => {
+  asyncWrapper(async (req: Request<GetWorkspaceParams>, res: Response) => {
     const { id: userId } = req.user;
     const { id: targetUserId } = req.params;
 

--- a/server/apis/user/controller.ts
+++ b/server/apis/user/controller.ts
@@ -2,13 +2,14 @@ import express, { Request, Response } from 'express';
 import asyncWrapper from '@utils/async-wrapper';
 import * as userService from './service';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
+import { getWorkspaceParams } from '@params/user';
 
 const router = express.Router();
 
 router.get(
   '/:id/workspace',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request<getWorkspaceParams>, res: Response) => {
     const { id: userId } = req.user;
     const { id: targetUserId } = req.params;
 

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -2,30 +2,31 @@ import express, { Request, Response } from 'express';
 import asyncWrapper from '@utils/async-wrapper';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
 import * as workspaceService from './service';
-import { OK } from '@constants/http-status';
+import { CREATED } from '@constants/http-status';
+import { postParams, postJoinParams } from '@params/workspace';
 
 const router = express.Router();
 
 router.post(
   '/',
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request<postParams>, res: Response) => {
     const { name } = req.body;
 
     const workspace = await workspaceService.create(name);
 
-    res.status(OK).send({ ...workspace });
+    res.status(CREATED).send({ ...workspace });
   }),
 );
 
 router.post(
   '/join',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request<postJoinParams>, res: Response) => {
     const { code } = req.body;
 
     const joinedWorkspace = await workspaceService.join(req.user.id, code);
 
-    res.status(OK).send(joinedWorkspace);
+    res.status(CREATED).send(joinedWorkspace);
   }),
 );
 

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -3,13 +3,13 @@ import asyncWrapper from '@utils/async-wrapper';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
 import * as workspaceService from './service';
 import { CREATED } from '@constants/http-status';
-import { postParams, postJoinParams } from '@params/workspace';
+import { PostParams, PostJoinParams } from '@params/workspace';
 
 const router = express.Router();
 
 router.post(
   '/',
-  asyncWrapper(async (req: Request<postParams>, res: Response) => {
+  asyncWrapper(async (req: Request<PostParams>, res: Response) => {
     const { name } = req.body;
 
     const workspace = await workspaceService.create(name);
@@ -21,7 +21,7 @@ router.post(
 router.post(
   '/join',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request<postJoinParams>, res: Response) => {
+  asyncWrapper(async (req: Request<PostJoinParams>, res: Response) => {
     const { code } = req.body;
 
     const joinedWorkspace = await workspaceService.join(req.user.id, code);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,7 +19,6 @@
     "esModuleInterop": true,
     "downlevelIteration": true,
     "typeRoots": ["../node_modules/@types", "./@types"],
-    "rootDir": ".",
     "outDir": "./dist",
     "plugins": [
       {

--- a/server/tsconfig.path.json
+++ b/server/tsconfig.path.json
@@ -8,7 +8,8 @@
       "@errors/*": ["errors/*"],
       "@db": ["db"],
       "@middlewares/*": ["middlewares/*"],
-      "@utils/*": ["utils/*"]
+      "@utils/*": ["utils/*"],
+      "@params/*": ["../types/params/*"]
     }
   }
 }

--- a/types/params/auth.ts
+++ b/types/params/auth.ts
@@ -1,0 +1,3 @@
+export interface postLoginParams {
+  code: string;
+}

--- a/types/params/auth.ts
+++ b/types/params/auth.ts
@@ -1,3 +1,3 @@
-export interface postLoginParams {
+export interface PostLoginParams {
   code: string;
 }

--- a/types/params/user.ts
+++ b/types/params/user.ts
@@ -1,0 +1,3 @@
+export interface getWorkspaceParams {
+  id: number;
+}

--- a/types/params/user.ts
+++ b/types/params/user.ts
@@ -1,3 +1,3 @@
-export interface getWorkspaceParams {
+export interface GetWorkspaceParams {
   id: number;
 }

--- a/types/params/workspace.ts
+++ b/types/params/workspace.ts
@@ -1,0 +1,7 @@
+export interface postParams {
+  name: string;
+}
+
+export interface postJoinParams {
+  code: string;
+}

--- a/types/params/workspace.ts
+++ b/types/params/workspace.ts
@@ -1,7 +1,7 @@
-export interface postParams {
+export interface PostParams {
   name: string;
 }
 
-export interface postJoinParams {
+export interface PostJoinParams {
   code: string;
 }


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve #57
- 루트 디렉토리에 API 파라미터 타입을 정의하고 절대경로를 설정했어요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 네이밍은 메서드 + 도메인을 제외한 경로로 사용했어요.

<br />

- model.exists() resolve 전에 조건문이 실행되어 최초 로그인하는 유저가 db에 저장되지 않는 문제가 있어 수정했어요.
  도훈님과 해결했던 것으로 기억하는데 pr 어딘가에서 사라졌나봐요..