### PR TITLE
Feat/#51-S : 특정 워크스페이스의 멤버, 회의록 목록 조회하기 API 구축

### DIFF
--- a/server/apis/user/model.ts
+++ b/server/apis/user/model.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'mongoose';
 import mongoose from '@db';
 
-interface User {
+export interface User {
   id: number;
   name: string;
   avatarUrl: string;

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -6,6 +6,7 @@ import { OK } from '@constants/http-status';
 
 const router = express.Router();
 
+/* POST: 워크스페이스 생성 */
 router.post(
   '/',
   asyncWrapper(async (req: Request, res: Response) => {
@@ -17,6 +18,7 @@ router.post(
   }),
 );
 
+/* POST: 워크스페이스 참여 */
 router.post(
   '/join',
   jwtAuthenticator,
@@ -26,6 +28,19 @@ router.post(
     const joinedWorkspace = await workspaceService.join(req.user.id, code);
 
     res.status(OK).send(joinedWorkspace);
+  }),
+);
+
+/* GET: 특정 워크스페이스의 멤버, 회의록 목록 */
+router.get(
+  '/:id',
+  jwtAuthenticator,
+  asyncWrapper(async (req: Request, res: Response) => {
+    const { id: workspaceId } = req.params;
+
+    const workspaceInfo = await workspaceService.info(+workspaceId);
+
+    res.send({ ...workspaceInfo });
   }),
 );
 

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -15,7 +15,7 @@ router.post(
 
     const workspace = await workspaceService.create(name);
 
-    res.status(CREATED).send({ ...workspace });
+    res.status(CREATED).send(workspace);
   }),
 );
 
@@ -39,9 +39,9 @@ router.get(
   asyncWrapper(async (req: Request, res: Response) => {
     const { id: workspaceId } = req.params;
 
-    const workspaceInfo = await workspaceService.info(+workspaceId);
+    const workspaceInfo = await workspaceService.info(Number(workspaceId));
 
-    res.send({ ...workspaceInfo });
+    res.send(workspaceInfo);
   }),
 );
 

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -3,7 +3,7 @@ import asyncWrapper from '@utils/async-wrapper';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
 import * as workspaceService from './service';
 import { CREATED } from '@constants/http-status';
-import { PostParams, PostJoinParams } from '@params/workspace';
+import { PostParams, PostJoinParams, GetInfoParams } from '@params/workspace';
 
 const router = express.Router();
 
@@ -36,7 +36,7 @@ router.post(
 router.get(
   '/:id',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request<GetInfoParams>, res: Response) => {
     const { id: workspaceId } = req.params;
 
     const workspaceInfo = await workspaceService.info(Number(workspaceId));

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -41,28 +41,19 @@ export const info = async (workspaceId: number) => {
   if (!workspace)
     throw new InvalidWorkspaceError('존재하지 않는 워크스페이스에요 ^^');
 
-  const { name, users, moms } = workspace;
+  const { name, users: usersInfo, moms: momsInfo } = workspace;
 
-  const usersInfo: Pick<User, 'name' | 'avatarUrl'>[] = [];
-  const momsInfo: string[] = [];
+  const users: Pick<User, 'name' | 'avatarUrl'>[] = await userModel.find(
+    {
+      id: { $in: usersInfo },
+    },
+    { name: 1, avatarUrl: 1, _id: 0 },
+  );
 
-  for await (const id of users) {
-    const user = await userModel.findOne({ id });
+  const moms: string[] = await momModel.find(
+    { id: { $in: momsInfo } },
+    { name: 1 },
+  );
 
-    if (user) {
-      const { name, avatarUrl } = user;
-      usersInfo.push({ name, avatarUrl });
-    }
-  }
-
-  for await (const id of moms) {
-    const mom = await momModel.findOne({ id });
-
-    if (mom) {
-      const { name } = mom;
-      momsInfo.push(name);
-    }
-  }
-
-  return { workspaceName: name, usersInfo, momsInfo };
+  return { name, users, moms };
 };

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -41,7 +41,7 @@ export const info = async (workspaceId: number) => {
   if (!workspace)
     throw new InvalidWorkspaceError('존재하지 않는 워크스페이스에요 ^^');
 
-  const { users, moms } = workspace;
+  const { name, users, moms } = workspace;
 
   const usersInfo: Pick<User, 'name' | 'avatarUrl'>[] = [];
   const momsInfo: string[] = [];
@@ -64,5 +64,5 @@ export const info = async (workspaceId: number) => {
     }
   }
 
-  return { usersInfo, momsInfo };
+  return { workspaceName: name, usersInfo, momsInfo };
 };

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -41,17 +41,17 @@ export const info = async (workspaceId: number) => {
   if (!workspace)
     throw new InvalidWorkspaceError('존재하지 않는 워크스페이스에요 ^^');
 
-  const { name, users: usersInfo, moms: momsInfo } = workspace;
+  const { name, users: userIds, moms: momsIds } = workspace;
 
   const users: Pick<User, 'name' | 'avatarUrl'>[] = await userModel.find(
     {
-      id: { $in: usersInfo },
+      id: { $in: userIds },
     },
     { name: 1, avatarUrl: 1, _id: 0 },
   );
 
   const moms: string[] = await momModel.find(
-    { id: { $in: momsInfo } },
+    { id: { $in: momsIds } },
     { name: 1 },
   );
 

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -34,7 +34,7 @@ export const join = async (userId: number, code: string) => {
 };
 
 export const info = async (workspaceId: number) => {
-  if (!workspaceId) throw new InvalidJoinError('잘못된 접근이에요 ^^');
+  if (!workspaceId) throw new InvalidWorkspaceError('잘못된 접근이에요 ^^');
 
   const workspace = await workspaceModel.findOne({ id: workspaceId });
 
@@ -43,17 +43,16 @@ export const info = async (workspaceId: number) => {
 
   const { name, users: userIds, moms: momsIds } = workspace;
 
-  const users: Pick<User, 'name' | 'avatarUrl'>[] = await userModel.find(
-    {
-      id: { $in: userIds },
-    },
-    { name: 1, avatarUrl: 1, _id: 0 },
-  );
+  const users: Pick<User, 'name' | 'avatarUrl'>[] =
+    (await userModel.find(
+      {
+        id: { $in: userIds },
+      },
+      { name: 1, avatarUrl: 1, _id: 0 },
+    )) || [];
 
-  const moms: string[] = await momModel.find(
-    { id: { $in: momsIds } },
-    { name: 1 },
-  );
+  const moms: string[] =
+    (await momModel.find({ id: { $in: momsIds } }, { name: 1 })) || [];
 
   return { name, users, moms };
 };

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -1,8 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import workspaceModel from './model';
-import userModel from '@apis/user/model';
+import userModel, { User } from '@apis/user/model';
+import momModel from '@apis/mom/model';
 import AuthorizationError from '@errors/authorization-error';
 import InvalidJoinError from '@errors/invalid-join-error';
+import InvalidWorkspaceError from '@errors/invalid-workspace-error';
 
 export const create = async (name: string) => {
   if (!name) throw new Error('워크스페이스 이름을 입력하세요 ^^');
@@ -29,4 +31,38 @@ export const join = async (userId: number, code: string) => {
   await userModel.updateOne({ id: userId }, { $push: { workspaces: id } });
 
   return { id, name, code };
+};
+
+export const info = async (workspaceId: number) => {
+  if (!workspaceId) throw new InvalidJoinError('잘못된 접근이에요 ^^');
+
+  const workspace = await workspaceModel.findOne({ id: workspaceId });
+
+  if (!workspace)
+    throw new InvalidWorkspaceError('존재하지 않는 워크스페이스에요 ^^');
+
+  const { users, moms } = workspace;
+
+  const usersInfo: Pick<User, 'name' | 'avatarUrl'>[] = [];
+  const momsInfo: string[] = [];
+
+  for await (const id of users) {
+    const user = await userModel.findOne({ id });
+
+    if (user) {
+      const { name, avatarUrl } = user;
+      usersInfo.push({ name, avatarUrl });
+    }
+  }
+
+  for await (const id of moms) {
+    const mom = await momModel.findOne({ id });
+
+    if (mom) {
+      const { name } = mom;
+      momsInfo.push(name);
+    }
+  }
+
+  return { usersInfo, momsInfo };
 };

--- a/server/errors/invalid-workspace-error.ts
+++ b/server/errors/invalid-workspace-error.ts
@@ -1,0 +1,10 @@
+import CustomError from '.';
+import { BAD_REQUEST } from '@constants/http-status';
+
+class InvalidWorkspaceError extends CustomError {
+  constructor(message = 'Unauthorized') {
+    super(message, BAD_REQUEST);
+  }
+}
+
+export default InvalidWorkspaceError;

--- a/types/params/workspace.ts
+++ b/types/params/workspace.ts
@@ -5,3 +5,7 @@ export interface PostParams {
 export interface PostJoinParams {
   code: string;
 }
+
+export interface GetInfoParams {
+  id: string;
+}


### PR DESCRIPTION
## 🤠 개요

- resolve #51 

## 💫 설명

- 워크스페이스 Id를 params로 받는 `workspace/:id` path의 컨트롤러 구현
- 멤버 정보와 회의록 정보를 받아오는 서비스 로직 구현
  - 워크스페이스의 users, moms 컬럼에 id 값 기준으로 들어가 있어서 각각 id 마다 userModel, momModel 을 돌렸어요
    - 기획서 상으로 `userModel` 에서 필요한 값은 name, avatarUrl 두개
    - `momModel` 에서 필요한 값은 name 밖에 없는 거 같아서 저 속성만 받아오도록 했어요
    - 틀린 부분 있으면 알려주세요
- 생각해보니까 헤더에 워크스페이스 이름도 필요해서 name 컬럼도 추가했어요

## 🌜 고민거리 (Optional)


## 📷 스크린샷 (Optional)
- 참고 UI
![스크린샷 2022-11-16 오후 3 36 22](https://user-images.githubusercontent.com/63364990/202102986-186a3329-65b2-4a83-8ff0-f834d1b69356.png)

- Postman 테스트
![스크린샷 2022-11-16 오후 3 41 50](https://user-images.githubusercontent.com/63364990/202104106-ef7c9d9c-d8d4-4e19-b287-232a1abc15b2.png)

- 테스팅 코드는 따로 브랜치 파서 작업할게요