### PR TITLE
Fix/#69-BK: 초기 접근 URL이 /workspace인 경우 /로 리다이렉트

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     setIsLoaded(true);
 
     if (!currentUser) {
-      if (location.pathname !== '/') navigate('/');
+      if (location.pathname === '/workspace') navigate('/');
       return;
     }
 


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- pathname !== '/'로 설정했을 때 /oauth로 리다이렉트된 상황에서도 OAuthPage가 렌더링되지 않고 navigate('/')가 실행됨
- 우선 이렇게 해결해두고 API 연동 작업 진행할 예정

Co-authored-by: 백도훈 <dohun31@users.noreply.github.com>

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)