### PR TITLE
Feat/#21-B: 워크스페이스 생성 모달 & API 연동

### DIFF
--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -4,6 +4,7 @@ import WorkspaceThumbnaliList from 'components/WorkspaceThumbnailList';
 import { memo, useEffect, useState } from 'react';
 import { getWorkspaces } from 'src/apis/user';
 import { MENUS } from 'src/constants/workspace';
+import SetWorkspacesContext from 'src/contexts/set-workspaces';
 import { useUserContext } from 'src/hooks/useUserContext';
 import { SelectorStyle } from 'src/types/selector';
 import { Workspace } from 'src/types/workspace';
@@ -41,7 +42,7 @@ function WorkspaceList() {
   };
 
   return (
-    <>
+    <SetWorkspacesContext.Provider value={setWorkspaces}>
       <div className={style.workspace__container}>
         <WorkspaceThumbnaliList workspaces={workspaces} />
         <Selector
@@ -55,7 +56,7 @@ function WorkspaceList() {
           setSelectedMenu={setSelectedMenu}
         />
       </div>
-    </>
+    </SetWorkspacesContext.Provider>
   );
 }
 

--- a/client/src/components/WorkspaceModal/CreateModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateModal.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
+import { postWorkspace } from 'src/apis/workspace';
+import { MENU } from 'src/constants/workspace';
 
 import FormModal, { ModalContents } from './FormModal';
 
@@ -6,17 +8,21 @@ interface CreateModalProps {
   modalContents: ModalContents;
   onClose: () => void;
   setSelectedMenu: React.Dispatch<React.SetStateAction<number>>;
+  setCode: React.Dispatch<React.SetStateAction<string>>;
 }
 
 function CreateModal({
   modalContents,
   onClose,
   setSelectedMenu,
+  setCode,
 }: CreateModalProps) {
   const [inputValue, setInputValue] = useState<string>('');
 
-  const onSubmit = () => {
-    setSelectedMenu(3);
+  const onSubmit = async () => {
+    const { code } = await postWorkspace({ name: inputValue });
+    setCode(code);
+    setSelectedMenu(MENU.CREATE_SUCCESS);
     return;
   };
 

--- a/client/src/components/WorkspaceModal/CreateModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { postWorkspace } from 'src/apis/workspace';
+import { postWorkspace, postWorkspaceJoin } from 'src/apis/workspace';
 import { MENU } from 'src/constants/workspace';
+import { useSetWorkspaces } from 'src/hooks/useSetWorkspaces';
+import { useUserContext } from 'src/hooks/useUserContext';
 
 import FormModal, { ModalContents } from './FormModal';
 
@@ -17,12 +19,19 @@ function CreateModal({
   setSelectedMenu,
   setCode,
 }: CreateModalProps) {
+  const setWorkspaces = useSetWorkspaces();
   const [inputValue, setInputValue] = useState<string>('');
 
   const onSubmit = async () => {
-    const { code } = await postWorkspace({ name: inputValue });
+    const { workspace } = await postWorkspace({ name: inputValue });
+    const { code } = workspace;
+
+    await postWorkspaceJoin({ code });
+
+    setWorkspaces((workspaces) => [...workspaces, workspace]);
     setCode(code);
     setSelectedMenu(MENU.CREATE_SUCCESS);
+
     return;
   };
 

--- a/client/src/components/WorkspaceModal/CreateModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateModal.tsx
@@ -23,7 +23,7 @@ function CreateModal({
   const [inputValue, setInputValue] = useState<string>('');
 
   const onSubmit = async () => {
-    const { workspace } = await postWorkspace({ name: inputValue });
+    const workspace = await postWorkspace({ name: inputValue });
     const { code } = workspace;
 
     await postWorkspaceJoin({ code });

--- a/client/src/components/WorkspaceModal/CreateSuccessModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateSuccessModal.tsx
@@ -2,11 +2,13 @@ import FormModal, { ModalContents } from './FormModal';
 
 interface CreateSuccessModalProps {
   modalContents: ModalContents;
+  code: string;
   onClose: () => void;
 }
 
 function CreateSuccessModal({
   modalContents,
+  code,
   onClose,
 }: CreateSuccessModalProps) {
   const onSubmit = () => {
@@ -19,7 +21,7 @@ function CreateSuccessModal({
       onClose={onClose}
       onSubmit={onSubmit}
       isDisabled
-      inputValue="WAB1234"
+      inputValue={code}
     />
   );
 }

--- a/client/src/components/WorkspaceModal/CreateSuccessModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateSuccessModal.tsx
@@ -12,6 +12,7 @@ function CreateSuccessModal({
   onClose,
 }: CreateSuccessModalProps) {
   const onSubmit = () => {
+    onClose();
     return;
   };
 

--- a/client/src/components/WorkspaceModal/index.tsx
+++ b/client/src/components/WorkspaceModal/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { MENU, MODAL_MENUS } from 'src/constants/workspace';
 
 import CreateModal from './CreateModal';
@@ -13,6 +14,8 @@ function WorkspaceModal({
   selectedMenu,
   setSelectedMenu,
 }: WorkspaceModalProps) {
+  const [code, setCode] = useState<string>('');
+
   const modalContents = MODAL_MENUS[selectedMenu];
 
   const onClose = () => setSelectedMenu(0);
@@ -24,11 +27,16 @@ function WorkspaceModal({
           modalContents={modalContents}
           onClose={onClose}
           setSelectedMenu={setSelectedMenu}
+          setCode={setCode}
         />
       );
     case MENU.CREATE_SUCCESS:
       return (
-        <CreateSuccessModal modalContents={modalContents} onClose={onClose} />
+        <CreateSuccessModal
+          modalContents={modalContents}
+          onClose={onClose}
+          code={code}
+        />
       );
     case MENU.JOIN:
       return <JoinModal modalContents={modalContents} onClose={onClose} />;

--- a/client/src/contexts/set-workspaces.ts
+++ b/client/src/contexts/set-workspaces.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import { Workspace } from 'src/types/workspace';
+
+type SetWorkspaces =
+  | React.Dispatch<React.SetStateAction<Workspace[]>>
+  | (() => void);
+
+const SetWorkspacesContext = createContext<SetWorkspaces>(() => {
+  return;
+});
+
+export default SetWorkspacesContext;

--- a/client/src/hooks/useSetWorkspaces.tsx
+++ b/client/src/hooks/useSetWorkspaces.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import SetWorkspacesContext from 'src/contexts/set-workspaces';
+
+export function useSetWorkspaces() {
+  const context = useContext(SetWorkspacesContext);
+
+  if (!context)
+    throw new Error('UserContext는 정의된 스코프 안에서만 사용 가능해요 ^^');
+
+  return context;
+}

--- a/server/apis/workspace/service.test.ts
+++ b/server/apis/workspace/service.test.ts
@@ -34,17 +34,18 @@ jest.mock('uuid', () => {
 
 describe('create', () => {
   it('워크스페이스 이름이 주어진 경우 생성에 성공한다.', async () => {
+    const WORKSPACE_ID = 1;
     const WORKSPACE_NAME = 'Wab';
 
-    workspaceModel.create.mockResolvedValueOnce({
+    const workspace = {
+      id: WORKSPACE_ID,
       name: WORKSPACE_NAME,
       code: VALID_CODE,
-    });
+    };
 
-    expect(workspaceService.create(WORKSPACE_NAME)).resolves.toEqual({
-      name: WORKSPACE_NAME,
-      code: VALID_CODE,
-    });
+    workspaceModel.create.mockResolvedValueOnce(workspace);
+
+    expect(workspaceService.create(WORKSPACE_NAME)).resolves.toEqual(workspace);
   });
 
   it('워크스페이스 이름이 없는 경우 생성에 실패한다.', async () => {

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -11,9 +11,9 @@ export const create = async (name: string) => {
 
   const code = uuidv4();
 
-  const workspace = await workspaceModel.create({ name, code });
+  const { id } = await workspaceModel.create({ name, code });
 
-  return { workspace };
+  return { id, name, code };
 };
 
 export const join = async (userId: number, code: string) => {

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -13,7 +13,7 @@ export const create = async (name: string) => {
 
   const workspace = await workspaceModel.create({ name, code });
 
-  return { name: workspace.name, code: workspace.code };
+  return { workspace };
 };
 
 export const join = async (userId: number, code: string) => {


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #21 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 워크스페이스를 생성할 수 있어요.
- 생성하면 WorkspaceList에 업데이트 돼요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### Q.(해결) `CreateModal`에서 `workspace`를 생성하고나서 `code`를 `CreateSuccess`에도 `code`가 필요해요.
고민을 해봤는데 CreateModal과 CreateSuccess는 code를 공유하기 때문에 어쩔 수 없이 의존관계가 되어 버려요.
그래서 `WorkspaceModal` 컴포넌트에서 `code` 상태를 만들고 `props`를 내려주는 방식으로 해결했어요.

### Q. `CreateModal`에서 workspace를 생생하고나서의 책임에 대해 고민해봤어요.
CreateModal이 workspace를 생성하는 api를 호출하면 workspaceList에 썸네일이 추가되어야 해요.
이전에는 api의 response로 `{name, code}`만 받고 있어서 workspace 자체를 response로 줄 수 있게 변경하려고 했어요.

그런데 제 생각에는 CreateModal이 해야하는 일은 `workspace를 생성한다.`까지 인것 같아서 생성 후에 workspaceList를 업데이트 시키는건 관심사가 다른 일이라고 생각을 했어요.
그래서 `SSE`를 사용해서 workspace를 생성하는 이벤트가 발생하면 server에서 client에게 알려주고 workspaceList는 그 이벤트를 구독하고 있다가 list를 업데이트 해주는식은 어떨까라고 고민을 했어요.

이 부분에 대해선 저희가 얘기를 해보고 적용하는게 맞다고 생각해서 일단 api를 수정하고 response로 workspace를 보내주게 했어요.

## 📷 스크린샷 (Optional)

<img src="https://user-images.githubusercontent.com/65100540/202385127-45fa6cba-df65-4882-8e91-4d977d7c6bfa.mov" height=500>



