### PR TITLE
Feat/#45-K: 워크스페이스 참여 모달 연동

### DIFF
--- a/client/src/apis/workspace.ts
+++ b/client/src/apis/workspace.ts
@@ -1,9 +1,12 @@
 import { PostJoinParams, PostParams } from 'params/workspace';
+import { Workspace } from 'src/types/workspace';
 
 import { http } from './http';
 import { CREATED } from './http-status';
 
-export const postWorkspace = async ({ name }: PostParams) => {
+export const postWorkspace = async ({
+  name,
+}: PostParams): Promise<Workspace> => {
   const res = await http.post(`/workspace`, { name });
 
   if (res.status !== CREATED) throw new Error();
@@ -11,7 +14,9 @@ export const postWorkspace = async ({ name }: PostParams) => {
   return res.data;
 };
 
-export const postWorkspaceJoin = async ({ code }: PostJoinParams) => {
+export const postWorkspaceJoin = async ({
+  code,
+}: PostJoinParams): Promise<Workspace> => {
   const res = await http.post(`/workspace/join`, { code });
 
   if (res.status !== CREATED) throw new Error();

--- a/client/src/components/WorkspaceList/index.tsx
+++ b/client/src/components/WorkspaceList/index.tsx
@@ -4,6 +4,7 @@ import WorkspaceThumbnaliList from 'components/WorkspaceThumbnailList';
 import { memo, useEffect, useState } from 'react';
 import { getWorkspaces } from 'src/apis/user';
 import { MENUS } from 'src/constants/workspace';
+import SetWorkspacesContext from 'src/contexts/set-workspaces';
 import { useUserContext } from 'src/hooks/useUserContext';
 import { SelectorStyle } from 'src/types/selector';
 import { Workspace } from 'src/types/workspace';
@@ -41,7 +42,7 @@ function WorkspaceList() {
   };
 
   return (
-    <>
+    <SetWorkspacesContext.Provider value={setWorkspaces}>
       <div className={style.workspace__container}>
         <WorkspaceThumbnaliList workspaces={workspaces} />
         <Selector
@@ -55,7 +56,7 @@ function WorkspaceList() {
           setSelectedMenu={setSelectedMenu}
         />
       </div>
-    </>
+    </SetWorkspacesContext.Provider>
   );
 }
 

--- a/client/src/components/WorkspaceModal/FormModal.tsx
+++ b/client/src/components/WorkspaceModal/FormModal.tsx
@@ -17,9 +17,10 @@ interface ModalContainerProps {
   btnText: string;
   onClose: () => void;
   onSubmit: () => void;
-  isDisabled?: boolean;
   inputValue: string;
   setInputValue?: React.Dispatch<React.SetStateAction<string>>;
+  isDisabled?: boolean;
+  errorMessage?: string;
 }
 
 function FormModal({
@@ -28,9 +29,10 @@ function FormModal({
   btnText,
   onClose,
   onSubmit,
-  isDisabled = false,
   inputValue,
   setInputValue,
+  isDisabled = false,
+  errorMessage = undefined,
 }: ModalContainerProps) {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (setInputValue) setInputValue(e.target.value);
@@ -40,7 +42,7 @@ function FormModal({
     <Modal title={title} onClose={onClose}>
       <>
         {texts.map((text) => (
-          <p key={text} className={style.text}>
+          <p key={text} className={style['text']}>
             {text}
           </p>
         ))}
@@ -48,13 +50,18 @@ function FormModal({
         <div className={style['input-section']}>
           {isDisabled && <BiCopy className={style['copy-icon']} />}
           <input
-            className={cx(style.input, { [style.disabled]: isDisabled })}
+            className={cx(style.input, {
+              [style.disabled]: isDisabled,
+              [style.invalid]: !!errorMessage,
+            })}
             type="text"
             value={inputValue}
             onChange={onChange}
             disabled={isDisabled}
           />
         </div>
+
+        {<p className={style['error-message']}>{errorMessage}</p>}
 
         <Button
           text={btnText}

--- a/client/src/components/WorkspaceModal/JoinModal.tsx
+++ b/client/src/components/WorkspaceModal/JoinModal.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { postWorkspaceJoin } from 'src/apis/workspace';
+import { useSetWorkspaces } from 'src/hooks/useSetWorkspaces';
 
 import FormModal, { ModalContents } from './FormModal';
 
@@ -10,8 +12,20 @@ interface JoinModalProps {
 function JoinModal({ modalContents, onClose }: JoinModalProps) {
   const [inputValue, setInputValue] = useState<string>('');
 
-  const onSubmit = () => {
-    return;
+  const setWorkspaces = useSetWorkspaces();
+
+  const onSubmit = async () => {
+    try {
+      const workspace = await postWorkspaceJoin({ code: inputValue });
+
+      setWorkspaces((prev) => {
+        return [...prev, workspace];
+      });
+
+      onClose();
+    } catch (e) {
+      console.log('에러 메세지 표시');
+    }
   };
 
   return (

--- a/client/src/components/WorkspaceModal/JoinModal.tsx
+++ b/client/src/components/WorkspaceModal/JoinModal.tsx
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/named
+import { AxiosError, AxiosResponse } from 'axios';
 import { useState } from 'react';
 import { postWorkspaceJoin } from 'src/apis/workspace';
 import { useSetWorkspaces } from 'src/hooks/useSetWorkspaces';
@@ -13,6 +15,9 @@ function JoinModal({ modalContents, onClose }: JoinModalProps) {
   const [inputValue, setInputValue] = useState<string>('');
 
   const setWorkspaces = useSetWorkspaces();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
 
   const onSubmit = async () => {
     try {
@@ -24,7 +29,9 @@ function JoinModal({ modalContents, onClose }: JoinModalProps) {
 
       onClose();
     } catch (e) {
-      console.log('에러 메세지 표시');
+      const { data } = (e as AxiosError).response as AxiosResponse;
+
+      setErrorMessage(data?.message ?? '다시 시도해주세요 ^^');
     }
   };
 
@@ -35,6 +42,7 @@ function JoinModal({ modalContents, onClose }: JoinModalProps) {
       onSubmit={onSubmit}
       inputValue={inputValue}
       setInputValue={setInputValue}
+      errorMessage={errorMessage}
     />
   );
 }

--- a/client/src/components/WorkspaceModal/style.module.scss
+++ b/client/src/components/WorkspaceModal/style.module.scss
@@ -22,10 +22,20 @@
     border-radius: 10px;
     padding: 10px;
     font-size: 14px;
-    margin: 15px 0;
+    margin-top: 15px;
   }
 }
 
 .disabled {
   text-align: center;
+}
+
+.invalid {
+  border: 1px solid $red !important;
+}
+
+.error-message {
+  margin: 10px;
+  color: $red;
+  font-size: 12px;
 }

--- a/client/src/contexts/set-workspaces.ts
+++ b/client/src/contexts/set-workspaces.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import { Workspace } from 'src/types/workspace';
+
+type SetWorkspaces =
+  | React.Dispatch<React.SetStateAction<Workspace[]>>
+  | (() => void);
+
+const SetWorkspacesContext = createContext<SetWorkspaces>(() => {
+  return;
+});
+
+export default SetWorkspacesContext;

--- a/client/src/hooks/useSetWorkspaces.tsx
+++ b/client/src/hooks/useSetWorkspaces.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import SetWorkspacesContext from 'src/contexts/set-workspaces';
+
+export function useSetWorkspaces() {
+  const context = useContext(SetWorkspacesContext);
+
+  if (!context)
+    throw new Error('UserContext는 정의된 스코프 안에서만 사용 가능해요 ^^');
+
+  return context;
+}


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- close #45 
- 서버 API와 워크스페이스 참여 모달 연동

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->
- 모달에서 참여코드를 입력해 특정 워크스페이스에 참여하는 기능을 구현했어요.
- postWorkspaceJoin 요청에서 에러가 발생하면 모달에서 에러 메세지가 나타나게 했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

-  catch로 잡히는 에러 객체에서 서버가 응답한 에러 메세지에 접근하려면 깊이가 깊어지고 타입 에러가 우수수 쏟아져요.
  ![image](https://user-images.githubusercontent.com/63814960/202384064-1f61ba87-c959-4208-a302-f8986740636c.png)
  에러 케이스 잡아내야 하는 경우가 있고, 공통 유틸은 이슈 나눠서 처리하는게 좋을 것 같아서 JoinModal에서는 as 타입 명시로 우회했어요.
  AxiosResponse 타입 import가 eslint import/named rule에 걸려서 disable 해놨는데 클라이언트 apis에 에러 핸들러를 추가하면서 제거할 예정이에요.

## 📷 스크린샷 (Optional)
![Nov-17-2022 16-04-36](https://user-images.githubusercontent.com/63814960/202383323-a57b6de7-49a0-43ce-b4c6-c04995be13b4.gif)
