### PR TITLE
Feat/#75-B: 워크스페이스 설정 모달 UI

### DIFF
--- a/client/src/components/WorkspaceModal/CreateModal.tsx
+++ b/client/src/components/WorkspaceModal/CreateModal.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { postWorkspace, postWorkspaceJoin } from 'src/apis/workspace';
 import { MENU } from 'src/constants/workspace';
 import { useSetWorkspaces } from 'src/hooks/useSetWorkspaces';
-import { useUserContext } from 'src/hooks/useUserContext';
 
 import FormModal, { ModalContents } from './FormModal';
 

--- a/client/src/components/WorkspaceSetting/SettingModal.tsx
+++ b/client/src/components/WorkspaceSetting/SettingModal.tsx
@@ -1,0 +1,48 @@
+import { BiCodeBlock } from '@react-icons/all-files/bi/BiCodeBlock';
+import { BiCopy } from '@react-icons/all-files/bi/BiCopy';
+import React from 'react';
+
+import Button from '../common/Button';
+import Modal from '../common/Modal';
+import style from './style.module.scss';
+
+interface SettingModalProps {
+  title: string;
+  onClose: () => void;
+}
+
+function SettingModal({ title, onClose }: SettingModalProps) {
+  const code = '1234';
+
+  const onClick = () => {
+    onClose();
+    return;
+  };
+
+  return (
+    <Modal title={title} isDark={true} onClose={onClose}>
+      <>
+        <label className={style['input-label']}>
+          <BiCodeBlock className={style['code-block-icon']} />
+          <span className={style['label-title']}>참여코드</span>
+        </label>
+        <div className={style['input-section']}>
+          <BiCopy className={style['copy-icon']} />
+          <input
+            className={style.input}
+            type="text"
+            value={code}
+            disabled={true}
+          />
+        </div>
+        <Button
+          className={style.button}
+          text="워크스페이스 탈퇴"
+          onClick={onClick}
+        ></Button>
+      </>
+    </Modal>
+  );
+}
+
+export default SettingModal;

--- a/client/src/components/WorkspaceSetting/index.tsx
+++ b/client/src/components/WorkspaceSetting/index.tsx
@@ -1,0 +1,26 @@
+import { MdSettings } from '@react-icons/all-files/md/MdSettings';
+import React, { useState } from 'react';
+
+import SettingModal from './SettingModal';
+
+function WorkspaceSetting() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <MdSettings
+        size={15}
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      />
+      {isOpen && <SettingModal title="워크스페이스 설정" onClose={onClose} />}
+    </>
+  );
+}
+
+export default WorkspaceSetting;

--- a/client/src/components/WorkspaceSetting/style.module.scss
+++ b/client/src/components/WorkspaceSetting/style.module.scss
@@ -1,0 +1,60 @@
+@import 'styles/color.module.scss';
+
+.text {
+  font-size: 14px;
+}
+
+.input-section {
+  position: relative;
+  width: 270px;
+  text-align: center;
+  margin-bottom: 12px;
+
+  .copy-icon {
+    position: absolute;
+    top: 50%;
+    transform: translate(0, -50%);
+    right: 42px;
+    cursor: pointer;
+    color: $white;
+  }
+
+  .input {
+    width: calc(100% - 6rem);
+    border: 1px solid $white;
+    border-radius: 10px;
+    padding: 10px;
+    font-size: 14px;
+    color: $white;
+
+    &:disabled {
+      background-color: $primary-100;
+    }
+  }
+}
+
+.input-label {
+  width: 192px;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  padding: 4px;
+
+  .code-block-icon {
+    padding: 0px 4px;
+    color: $white;
+  }
+
+  .label-title {
+    color: $white;
+  }
+}
+
+.button {
+  display: flex;
+  justify-content: center;
+  background-color: $red;
+  height: 40px;
+  max-width: 270px;
+  border-radius: 10px;
+}

--- a/client/src/components/common/Modal/index.tsx
+++ b/client/src/components/common/Modal/index.tsx
@@ -1,19 +1,23 @@
 import { MdClose } from '@react-icons/all-files/md/MdClose';
+import classNames from 'classnames/bind';
 import Portal from 'common/Modal/Portal';
 
 import style from './style.module.scss';
 
+const cx = classNames.bind(style);
+
 interface ModalProps {
   title?: string;
+  isDark?: boolean;
   children: JSX.Element;
   onClose: () => void;
 }
 
-function Modal({ title, children, onClose }: ModalProps) {
+function Modal({ title, isDark = false, children, onClose }: ModalProps) {
   return (
     <Portal>
       <div
-        className={style.modal}
+        className={cx(style.modal, { 'dark-modal': isDark })}
         role="alertdialog"
         aria-modal
         aria-labelledby="modal"

--- a/client/src/components/common/Modal/style.module.scss
+++ b/client/src/components/common/Modal/style.module.scss
@@ -55,3 +55,15 @@
     }
   }
 }
+
+.dark-modal {
+  .out-container {
+    background-color: $primary-100;
+
+    .header {
+      background-color: $primary-100;
+      color: $white;
+      border-bottom: 1px solid $white;
+    }
+  }
+}

--- a/client/src/types/workspace.d.ts
+++ b/client/src/types/workspace.d.ts
@@ -1,4 +1,5 @@
 export interface Workspace {
   id: number;
   name: string;
+  code: string;
 }


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #75 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

워크스페이스 설정 모달 UI를 만들었어요.

원래 Sidebar의 헤더에 들어가야 하는데 현재는 헤더 UI가 없어서 설정 컴포넌트만 만들었어요!
나중에 세영님 저거 가져다 쓰시면 돼요!

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### Q. module css에서 style 덮어쓰기(?)를 할 수 있을까요?
워크스페이스 설정 모달을 Modal 컴포넌트를 사용해서 만들었는데 이 모달만 다크모드더라구요.
그래서 이 모달에서만 모달 컴포넌트의 스타일이 수정되어야 하는데 어렵더라구요.
일단 module css가 classname이 겹쳐도 적용됐을 때 뒤에 해시값같은걸 붙여서 고유하게 만들어주는데 이 특성때문에 제가 아무리 설정모달에서 상위 class를 붙여서 하위 class들을 조작해보려고 해도 안되더라구요.

그래서 현재는 Modal 컴포넌트에 `isDark`라는 props를 전달해요. 만약에 `isDark`가 true라면 다크 모드의 모달을 만들어줘요.

혹시 더 좋은 방법이 있을까요?
원래 제 의도는 Workspace의 SettingModal 자체에서 style을 조작하고 싶었는데 이렇게 할 수 있을까요? module css에 대해서 더 공부해봐야겠네요.

## 📷 스크린샷 (Optional)

<img src="https://user-images.githubusercontent.com/65100540/202431343-499759be-7b41-4df0-8e3f-dbf5a60dfd8a.mov" height=500>
