### PR TITLE
Chore: 배포 자동화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,20 @@
+name: cd
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy
+      uses: appleboy/ssh-action@v0.1.4
+      with:
+        host: ${{ secrets.SSH_HOST }}
+        username: ${{ secrets.SSH_USERNAME }}
+        password: ${{ secrets.SSH_PASSWORD }}
+        port: ${{ secrets.SSH_PORT }}
+        script: ${{ secrets.DEPLOY_SCRIPT }}


### PR DESCRIPTION


## 🤠 개요

- resolves #88

## 💫 설명

main 브랜치에 푸시할 때마다 배포합니다.

배포 서버에 있는 배포 스크립트를 실행시켜서 프론트와 백을 각각 빌드합니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)

fork repo에서 정상작동 확인했어요.

![screenshot](https://user-images.githubusercontent.com/89635107/202657356-1c31a9f2-ecc8-4ccb-9080-e0720b09f3b0.png)
