### PR TITLE
Fix/#107-C: 프록시를 위해 백엔드 api 주소 수정

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -15,9 +15,9 @@ app.use(cookieParser(env.COOKIE_SECRET_KEY));
 app.use(cors());
 
 app.get('/', (req: Request, res: Response) => res.send('Express'));
-app.use('/auth', authRouter);
-app.use('/workspace', workspaceRouter);
-app.use('/user', userRouter);
+app.use('/api/auth', authRouter);
+app.use('/api/workspace', workspaceRouter);
+app.use('/api/user', userRouter);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## 🤠 개요

- resolves #107 

## 💫 설명

nginx에서 proxying으로 '/api'로 시작하는 주소를 백엔드로 보내려고 합니다.
그렇게 하기 위해 백엔드 api 주소 앞에 '/api'를 추가했습니다.

이 PR이 머지되면 로컬에서 `.env` 파일도 수정해야 합니다.
클라이언트가 알고있는 서버 주소에 `/api`를 추가하면 됩니다.

## 🌜 고민거리 (Optional)

고민/해결 과정은 별도 이슈에 작성했습니다

- #106

## 📷 스크린샷 (Optional)

이 PR과 별개지만 프록시 설정이 다 끝났을 때 모습입니다.

![resolved](https://user-images.githubusercontent.com/89635107/203278746-4efc13d2-563e-4d6d-b181-89c385aae41c.gif)

`http`로 접근시 `https`로, `www`가 없을 때 `www`를 붙인 주소로 리다이렉션 합니다.

백엔드랑 문제없이 요청/응답하기 때문에 `/`로 접근하면 `/workspace`로 넘어갑니다.