### PR TITLE
Feat/#120-C: 시그널링 서버 연결 모듈

### DIFF
--- a/client/src/utils/webrtc/peer-com.ts
+++ b/client/src/utils/webrtc/peer-com.ts
@@ -1,0 +1,128 @@
+import { Socket } from 'socket.io';
+
+type onMediaConnectedCb = (socketId: string, remoteStream: MediaStream) => void;
+type onMediaDisconnectedCb = (socketId: string) => void;
+
+class PeerCom {
+  static BITRATE = 30000;
+  private signalingServerSocket: Socket;
+  private iceServerUrls: string[];
+  private userMediaStream: MediaStream;
+  private connections: Map<string, RTCPeerConnection>;
+  private streams: Map<string, MediaStream>;
+  private onMediaConnectedCallback: onMediaConnectedCb;
+  private onMediaDisconnectedCallback: onMediaDisconnectedCb;
+
+  constructor(signalingServerSocket: Socket, iceServerUrls: string[], userMediaStream: MediaStream) {
+    this.signalingServerSocket = signalingServerSocket;
+    this.iceServerUrls = iceServerUrls;
+    this.userMediaStream = userMediaStream;
+    this.connections = new Map();
+    this.streams = new Map();
+    this.onMediaConnectedCallback = () => { }; // eslint-disable-line @typescript-eslint/no-empty-function
+    this.onMediaDisconnectedCallback = () => { }; // eslint-disable-line @typescript-eslint/no-empty-function
+  }
+
+  onMediaConnected(callback: onMediaConnectedCb) {
+    this.onMediaConnectedCallback = callback;
+  }
+
+  onMediaDisconnected(callback: onMediaDisconnectedCb) {
+    this.onMediaDisconnectedCallback = callback;
+  }
+
+  #createPeerConnection(remoteSocketId: string) {
+    // initialize
+    const pcOptions = {
+      iceServers: [ { urls: this.iceServerUrls }],
+    };
+    const pc = new RTCPeerConnection(pcOptions);
+
+    // add event listeners
+    pc.addEventListener('icecandidate', iceEvent => {
+      this.signalingServerSocket.emit('__peercom_send_ice', iceEvent.candidate, remoteSocketId);
+    });
+    pc.addEventListener('track', async (event) => {
+      if (this.streams.has(remoteSocketId)) {
+        return;
+      }
+
+      const [remoteStream] = event.streams;
+
+      this.streams.set(remoteSocketId, remoteStream);
+      this.onMediaConnectedCallback(remoteSocketId, remoteStream);
+    });
+
+    // add tracks
+    this.userMediaStream.getTracks().forEach(track => pc.addTrack(track, this.userMediaStream));
+
+    return pc;
+  }
+
+  async #setVideoBitrate(pc: RTCPeerConnection, bitrate: number) {
+    // fetch video sender
+    const [videoSender] = pc.getSenders().filter(sender => sender!.track!.kind === 'video');
+
+    // set bitrate
+    const params = videoSender.getParameters();
+    params.encodings[0].maxBitrate = bitrate;
+    await videoSender.setParameters(params);
+  }
+
+  connect() {
+    this.signalingServerSocket.on('receive_hello', async (remoteSocketId) => {
+      const pc = this.#createPeerConnection(remoteSocketId);
+      this.connections.set(remoteSocketId, pc);
+
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+
+      this.signalingServerSocket.emit('send_offer', pc.localDescription, remoteSocketId);
+    });
+
+    this.signalingServerSocket.on('receive_offer', async (offer, remoteSocketId) => {
+      const pc = this.#createPeerConnection(remoteSocketId);
+      this.connections.set(remoteSocketId, pc);
+
+      await pc.setRemoteDescription(offer);
+
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+
+      this.#setVideoBitrate(pc, PeerCom.BITRATE);
+
+      this.signalingServerSocket.emit('send_answer', answer, remoteSocketId);
+    });
+
+    this.signalingServerSocket.on('receive_answer', async (answer, remoteSocketId) => {
+      const pc = this.connections.get(remoteSocketId);
+      if (!pc) {
+        throw new Error('No RTCPeerConnection on answer received.');
+      }
+
+      await pc.setRemoteDescription(answer);
+
+      this.#setVideoBitrate(pc, PeerCom.BITRATE);
+    });
+
+    this.signalingServerSocket.on('receive_ice', (ice, remoteSocketId) => {
+      const pc = this.connections.get(remoteSocketId);
+      if (!pc) {
+        throw new Error('No RTCPeerConnection on ice candindate received.');
+      }
+
+      pc.addIceCandidate(ice);
+    });
+
+    this.signalingServerSocket.on('receive_bye', remoteSocketId => {
+      this.connections.delete(remoteSocketId);
+      this.streams.delete(remoteSocketId);
+
+      this.onMediaDisconnectedCallback(remoteSocketId);
+    })
+
+    this.signalingServerSocket.emit('send_hello');
+  }
+}
+
+export default PeerCom;


### PR DESCRIPTION
## 🤠 개요

- #120 

## 💫 설명

시그널링 서버 연결 후 피어의 미디어 스트림을 갖고 오기까지의 로직을 추상화한 모듈입니다.

- `onMediaConnect(callback)`: 피어와 연결 시 피어의 아이디와 미디어스트림을 callback에 전달합니다.
- `onMediaDisconnect(callback)`: 피어와 연결 끊김 시 피어의 아이디를 callback에 전달합니다.
- `connect()`: 위 방법으로 이벤트 핸들러 등록 후 연결을 시도합니다.

사용 예시:
```javascript
peerCom.onMediaConnect((id, remoteStream) => {
  // 비디오 추가 렌더링과 같은 할 일
  // 예: video.srcObject = remoteStream
});

peerCom.onMediaDisconnect(id => {
  // 비디오 제거 렌더링과 같은 할 일
});

peerCom.connect();
```

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)