### PR TITLE
Refactor/#118-K: useCRDT로 CRDT 관련 로직 분리

### DIFF
--- a/@wabinar-crdt/index.ts
+++ b/@wabinar-crdt/index.ts
@@ -1,12 +1,12 @@
 import LinkedList from './linked-list';
 import { Identifier, Node } from './node';
 
-interface RemoteInsertOperation {
+export interface RemoteInsertOperation {
   prevId: Identifier | null;
   node: Node;
 }
 
-interface RemoteRemoveOperation {
+export interface RemoteDeleteOperation {
   targetId: Identifier | null;
   clock: number;
 }
@@ -16,7 +16,7 @@ class CRDT {
   private client: number;
   private structure: LinkedList;
 
-  constructor(initialclock: number, client: number) {
+  constructor(initialclock: number = 1, client: number = 0) {
     this.clock = initialclock;
     this.client = client;
     this.structure = new LinkedList();
@@ -43,7 +43,7 @@ class CRDT {
     return { prevId, node };
   }
 
-  localDelete(index: number): RemoteRemoveOperation {
+  localDelete(index: number): RemoteDeleteOperation {
     const targetId = this.structure.deleteByIndex(index);
 
     return { targetId, clock: this.clock };
@@ -59,7 +59,7 @@ class CRDT {
     return prevIndex;
   }
 
-  remoteDelete({ targetId, clock }: RemoteRemoveOperation) {
+  remoteDelete({ targetId, clock }: RemoteDeleteOperation) {
     const targetIndex = this.structure.deleteById(targetId);
 
     if (++this.clock < clock) {

--- a/client/src/hooks/useCRDT.tsx
+++ b/client/src/hooks/useCRDT.tsx
@@ -1,0 +1,95 @@
+import CRDT, {
+  RemoteInsertOperation,
+  RemoteDeleteOperation,
+} from '@wabinar/crdt';
+import { useRef } from 'react';
+import { useUserContext } from 'src/hooks/useUserContext';
+
+enum OPERATION_TYPE {
+  INSERT,
+  DELETE,
+}
+
+interface RemoteOperation {
+  type: OPERATION_TYPE;
+  op: RemoteDeleteOperation | RemoteInsertOperation;
+}
+
+function useCRDT() {
+  const crdtRef = useRef<CRDT>(new CRDT());
+  const userContext = useUserContext();
+
+  let initialized = false;
+  const operationSet: RemoteOperation[] = [];
+
+  const syncCRDT = (object: unknown) => {
+    Object.setPrototypeOf(object, CRDT.prototype);
+
+    crdtRef.current = object as CRDT;
+    crdtRef.current.setClientId(userContext.userInfo?.user.id);
+
+    initialized = true;
+    operationSet.forEach(({ type, op }) => {
+      switch (type) {
+        case OPERATION_TYPE.INSERT:
+          remoteInsertCRDT(op as RemoteInsertOperation);
+          break;
+        case OPERATION_TYPE.DELETE:
+          remoteDeleteCRDT(op as RemoteDeleteOperation);
+          break;
+        default:
+          break;
+      }
+    });
+  };
+
+  const readCRDT = (): string => {
+    if (!initialized) return '';
+    return crdtRef.current.read();
+  };
+
+  const localInsertCRDT = (index: number, letter: string) => {
+    const remoteInsertion = crdtRef.current.localInsert(index, letter);
+
+    return remoteInsertion;
+  };
+
+  const localDeleteCRDT = (index: number) => {
+    const targetIndex = crdtRef.current.localDelete(index);
+
+    return targetIndex;
+  };
+
+  const remoteInsertCRDT = (op: RemoteInsertOperation) => {
+    if (!initialized) {
+      operationSet.push({ type: OPERATION_TYPE.INSERT, op });
+      return null;
+    }
+
+    const prevIndex = crdtRef.current.remoteInsert(op);
+
+    return prevIndex;
+  };
+
+  const remoteDeleteCRDT = (op: RemoteDeleteOperation) => {
+    if (!initialized) {
+      operationSet.push({ type: OPERATION_TYPE.DELETE, op });
+      return null;
+    }
+
+    const targetIndex = crdtRef.current.remoteDelete(op);
+
+    return targetIndex;
+  };
+
+  return {
+    syncCRDT,
+    readCRDT,
+    localInsertCRDT,
+    localDeleteCRDT,
+    remoteInsertCRDT,
+    remoteDeleteCRDT,
+  };
+}
+
+export default useCRDT;


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Resolve #118
#117 작업 리팩토링을 위해 커스텀 훅 추가

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- crdtRef의 초기값 dummy crdt로 지정
- syncCRDT에서 crdtRef가 초기화 되기 전 remote 연산들이 수행되지 않도록 initialized, operationSet 사용
- remote operation 타입 네이밍 수정 및 export

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)