### PR TITLE
Refactor/#129-K: ConfMediaBar 컴포넌트 관련 리팩토링

### DIFF
--- a/client/src/components/ConfMediaBar/index.tsx
+++ b/client/src/components/ConfMediaBar/index.tsx
@@ -1,11 +1,20 @@
+import { io } from 'socket.io-client';
+import config from 'src/config';
+import { useConfMediaStreams } from 'src/hooks/useConfMediaStreams';
+
 import ConfMedia from './ConfMedia';
 import style from './style.module.scss';
 
 interface ConfMediaBarProps {
-  streams: Map<string, MediaStream>;
+  workspaceId?: string;
 }
 
-function ConfMediaBar({ streams }: ConfMediaBarProps) {
+function ConfMediaBar({ workspaceId }: ConfMediaBarProps) {
+  const socketUrl = `${config.SERVER_PATH}/signaling/${workspaceId}`;
+  const socket = io(socketUrl);
+
+  const streams = useConfMediaStreams(socket);
+
   return (
     <div className={style['conf-bar']}>
       <ul>

--- a/client/src/components/ConfMediaBar/index.tsx
+++ b/client/src/components/ConfMediaBar/index.tsx
@@ -1,5 +1,5 @@
 import { io } from 'socket.io-client';
-import config from 'src/config';
+import env from 'src/config';
 import { useConfMediaStreams } from 'src/hooks/useConfMediaStreams';
 
 import ConfMedia from './ConfMedia';
@@ -10,7 +10,7 @@ interface ConfMediaBarProps {
 }
 
 function ConfMediaBar({ workspaceId }: ConfMediaBarProps) {
-  const socketUrl = `${config.SERVER_PATH}/signaling/${workspaceId}`;
+  const socketUrl = `${env.SERVER_PATH}/signaling/${workspaceId}`;
   const socket = io(socketUrl);
 
   const streams = useConfMediaStreams(socket);

--- a/client/src/components/Confbar/index.tsx
+++ b/client/src/components/Confbar/index.tsx
@@ -1,5 +1,0 @@
-function Confbar() {
-  return <div></div>;
-}
-
-export default Confbar;

--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -1,22 +1,33 @@
-import Confbar from 'components/Confbar';
 import Mom from 'components/Mom';
 import Sidebar from 'components/Sidebar';
-import { TMom } from 'src/types/mom';
-import { TUser } from 'src/types/user';
-
+import { useEffect, useState } from 'react';
+import { getWorkspaceInfo } from 'src/apis/workspace';
+import { WorkspaceInfo } from 'src/types/workspace';
 interface WorkspaceProps {
-  name: string;
-  members: TUser[];
-  moms: TMom[];
+  workspaceId?: string;
 }
 
-function Workspace({ name, members, moms }: WorkspaceProps) {
+function Workspace({ workspaceId }: WorkspaceProps) {
+  const [workspace, setWorkspace] = useState<WorkspaceInfo | null>(null);
+
+  useEffect(() => {
+    loadWorkspaceInfo();
+  }, []);
+
+  const loadWorkspaceInfo = async () => {
+    if (workspaceId) {
+      const workspaceInfo = await getWorkspaceInfo({ id: workspaceId });
+      setWorkspace(workspaceInfo);
+    }
+  };
+
   return (
-    <>
-      <Sidebar />
-      <Mom />
-      <Confbar />
-    </>
+    workspace && (
+      <>
+        <Sidebar />
+        <Mom />
+      </>
+    )
   );
 }
 

--- a/client/src/hooks/useConfMediaStreams.tsx
+++ b/client/src/hooks/useConfMediaStreams.tsx
@@ -4,29 +4,48 @@ import { STUN_SERVER } from 'src/constants/rtc';
 import RTC from 'src/utils/rtc';
 
 export function useConfMediaStreams(socket: Socket) {
-  const [mediaStreams, setMediaStreams] = useState<Map<string, MediaStream>>(new Map());
+  const [mediaStreams, setMediaStreams] = useState<Map<string, MediaStream>>(
+    new Map(),
+  );
+
+  const initRTC = async () => {
+    const userMedia = await navigator.mediaDevices.getUserMedia({
+      video: true,
+      audio: true,
+    });
+    setMediaStreams((prev) =>
+      copyMapWithOperation(prev, (map) => map.set('me', userMedia)),
+    );
+
+    const rtc = new RTC(socket, STUN_SERVER, userMedia);
+
+    rtc.onMediaConnected((socketId, remoteStream) => {
+      setMediaStreams((prev) =>
+        copyMapWithOperation(prev, (map) => map.set(socketId, remoteStream)),
+      );
+    });
+
+    rtc.onMediaDisconnected((socketId) => {
+      setMediaStreams((prev) =>
+        copyMapWithOperation(prev, (map) => map.delete(socketId)),
+      );
+    });
+
+    rtc.connect();
+  };
 
   useEffect(() => {
-    (async () => {
-      const userMedia = await navigator.mediaDevices.getUserMedia({video: true, audio: true});
-      setMediaStreams(prev => copyMapWithOperation(prev, map => map.set('me', userMedia)));
-
-      const rtc = new RTC(socket, STUN_SERVER, userMedia);
-      rtc.onMediaConnected((socketId, remoteStream) => {
-        setMediaStreams(prev => copyMapWithOperation(prev, map => map.set(socketId, remoteStream)));
-      });
-      rtc.onMediaDisconnected((socketId) => {
-        setMediaStreams(prev => copyMapWithOperation(prev, map => map.delete(socketId)));
-      });
-      rtc.connect();
-  })();
-  }, [])
+    initRTC();
+  }, []);
 
   return mediaStreams;
 }
 
 // TODO: 코드 반복때문에 만든 함수. 더 좋은 방법 있으면 고치기
-function copyMapWithOperation<K, V>(prev: Map<K, V>, operation: (cur: Map<K, V>) => void) {
+function copyMapWithOperation<K, V>(
+  prev: Map<K, V>,
+  operation: (cur: Map<K, V>) => void,
+) {
   const cur = new Map(prev);
   operation(cur);
   return cur;

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -2,23 +2,15 @@ import Workspace from 'components/Workspace';
 import WorkspaceList from 'components/WorkspaceList';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { io } from 'socket.io-client';
 import { getWorkspaceInfo } from 'src/apis/workspace';
 import ConfMediaBar from 'src/components/ConfMediaBar';
-import config from 'src/config';
-import { useConfMediaStreams } from 'src/hooks/useConfMediaStreams';
 import { WorkspaceInfo } from 'src/types/workspace';
 
 import style from './style.module.scss';
 
 function WorkspacePage() {
-  const [workspace, setWorkspace] = useState<WorkspaceInfo | null>(null);
-
   const { id } = useParams();
-  const socketUrl = `${config.SERVER_PATH}/signaling/${id}`;
-  const socket = io(socketUrl);
-
-  const confMediaStreams = useConfMediaStreams(socket);
+  const [workspace, setWorkspace] = useState<WorkspaceInfo | null>(null);
 
   const loadWorkspaceInfo = async () => {
     if (id) {
@@ -41,7 +33,7 @@ function WorkspacePage() {
           moms={workspace.moms}
         />
       )}
-      <ConfMediaBar streams={confMediaStreams} />
+      <ConfMediaBar workspaceId={id} />
     </div>
   );
 }

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -1,38 +1,17 @@
 import Workspace from 'components/Workspace';
 import WorkspaceList from 'components/WorkspaceList';
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { getWorkspaceInfo } from 'src/apis/workspace';
 import ConfMediaBar from 'src/components/ConfMediaBar';
-import { WorkspaceInfo } from 'src/types/workspace';
 
 import style from './style.module.scss';
 
 function WorkspacePage() {
   const { id } = useParams();
-  const [workspace, setWorkspace] = useState<WorkspaceInfo | null>(null);
-
-  const loadWorkspaceInfo = async () => {
-    if (id) {
-      const workspaceInfo = await getWorkspaceInfo({ id });
-      setWorkspace(workspaceInfo);
-    }
-  };
-
-  useEffect(() => {
-    loadWorkspaceInfo();
-  }, []);
 
   return (
     <div className={style.container}>
       <WorkspaceList />
-      {workspace && ( // TODO: 임시로 만들었어요
-        <Workspace
-          name={workspace.name}
-          members={workspace.members}
-          moms={workspace.moms}
-        />
-      )}
+      <Workspace workspaceId={id} />
       <ConfMediaBar workspaceId={id} />
     </div>
   );


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Close #129 
ConfMediaBar 컴포넌트 관련해 필요한 리팩토링을 진행했어요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 원희님이 이슈 열어두셨던 즉시 실행 함수 제거
- Workspace 페이지의 workspace 상태를 사용되는 컴포넌트로 이동했어요.
  이제 페이지 단에서 리렌더가 발생하지 않아서 RTC 소켓도 ConfMediaBar 컴포넌트로 옮겼어요.

<br />

#131 PR에서 소켓 연결 경로를 수정했어요.
이쪽 브랜치 코드로는 회의록 소켓 연결이 안될거에요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

Q. workspaceId를 props로 내려주고 있는데 useParams 사용해서 컴포넌트 각각에서도 id 정보를 알 수 있어요. (Editor 컴포넌트에서 그렇게 사용중이에요.)
둘 중에 뭐가 더 좋은 방식일까요?

## 📷 스크린샷 (Optional)