### PR TITLE
Fix/#137-C: 배포 서버에서 @wabinar/crdt 못찾는 이슈 해결

### DIFF
--- a/server/tsconfig.path.json
+++ b/server/tsconfig.path.json
@@ -10,7 +10,8 @@
       "@middlewares/*": ["middlewares/*"],
       "@utils/*": ["utils/*"],
       "@params/*": ["../types/params/*"],
-      "@socket": ["socket"]
+      "@socket": ["socket"],
+      "@wabinar/crdt": ["../@wabinar-crdt"]
     }
   }
 }


### PR DESCRIPTION
## 🤠 개요

- resolve #137

## 💫 설명

tsconfig.path에 따로 추가함으로써, 빌드시 path alias를 resolve 시키도록 함

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)