### PR TITLE
Feat/#140-B: VoteBlock UI 구현

### DIFF
--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -21,13 +21,13 @@ const initialOption: Option[] = [
 
 function VoteBlock() {
   const [options, setOptions] = useState<Option[]>(initialOption);
-  const [isWriting, setIsWriting] = useState<boolean>(true);
+  const [isUnRegisterd, setIsUnRegisterd] = useState<boolean>(true);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const onRegister = () => {
-    if (!isWriting) return;
+    if (!isUnRegisterd) return;
 
-    setIsWriting(false);
+    setIsUnRegisterd(false);
   };
 
   const onAdd = () => {
@@ -60,7 +60,7 @@ function VoteBlock() {
           <li className={style['option-item']} key={id} id={id.toString()}>
             <div className={style['box-fill']}>{index + 1}</div>
             <p className={style.option}>{option}</p>
-            {isWriting && (
+            {isUnRegisterd && (
               <div
                 className={cx('box-fill', { 'position-right': true })}
                 onClick={() => onDelete(id)}
@@ -71,7 +71,7 @@ function VoteBlock() {
           </li>
         ))}
       </ul>
-      {isWriting && (
+      {isUnRegisterd && (
         <>
           <div className={style['option-item']}>
             <div className={style['box-fill']}></div>

--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -26,6 +26,8 @@ function VoteBlock() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const onRegister = () => {
+    if (!options.length) throw new Error('투표 항목은 최소 1개에요 ^^');
+
     if (!isUnRegisterd) return;
 
     setIsUnRegisterd(false);
@@ -53,6 +55,12 @@ function VoteBlock() {
     setOptions(filteredOptions);
   };
 
+  const onClose = () => {
+    alert('투표 종료..!');
+    /**투표 결과 보여줘야함 */
+    setIsUnRegisterd(true);
+  };
+
   return (
     <div className={style['vote-container']}>
       <h3 className={style.title}>투표</h3>
@@ -73,25 +81,25 @@ function VoteBlock() {
         ))}
       </ul>
       {isUnRegisterd && (
-        <>
-          <div className={style['option-item']}>
-            <div className={style['box-fill']}></div>
-            <input
-              ref={inputRef}
-              className={style['option-input']}
-              placeholder="항목을 입력해주세요"
-            ></input>
-          </div>
-          <div className={style['vote-buttons']}>
-            <Button className={style.button} onClick={onAdd} text="항목 추가" />
-            <Button
-              className={style.button}
-              onClick={onRegister}
-              text="투표 등록"
-            />
-          </div>
-        </>
+        <div className={style['option-item']}>
+          <div className={style['box-fill']}></div>
+          <input
+            ref={inputRef}
+            className={style['option-input']}
+            placeholder="항목을 입력해주세요"
+          ></input>
+        </div>
       )}
+      <div className={style['vote-buttons']}>
+        {isUnRegisterd ? (
+          <>
+            <Button onClick={onAdd} text="항목 추가" />
+            <Button onClick={onRegister} text="투표 등록" />
+          </>
+        ) : (
+          <Button onClick={onClose} text="투표 종료" />
+        )}
+      </div>
     </div>
   );
 }

--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -2,6 +2,7 @@ import { BiX } from '@react-icons/all-files/bi/BiX';
 import classNames from 'classnames/bind';
 import React, { useState, useRef } from 'react';
 
+import Button from '../common/Button';
 import style from './style.module.scss';
 
 const cx = classNames.bind(style);
@@ -82,12 +83,12 @@ function VoteBlock() {
             ></input>
           </div>
           <div className={style['vote-buttons']}>
-            <button className={style.button} onClick={onAdd}>
-              항목 추가
-            </button>
-            <button className={style.button} onClick={onRegister}>
-              투표 등록
-            </button>
+            <Button className={style.button} onClick={onAdd} text="항목 추가" />
+            <Button
+              className={style.button}
+              onClick={onRegister}
+              text="투표 등록"
+            />
           </div>
         </>
       )}

--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -45,11 +45,11 @@ function VoteBlock() {
   };
 
   const onDelete = (targetId: number) => {
-    const filterdOptions = options.filter(
+    const filteredOptions = options.filter(
       (option) => option.id !== Number(targetId),
     );
 
-    setOptions(filterdOptions);
+    setOptions(filteredOptions);
   };
 
   return (

--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -1,0 +1,100 @@
+import { BiX } from '@react-icons/all-files/bi/BiX';
+import classNames from 'classnames/bind';
+import React, { useState, useRef } from 'react';
+
+import style from './style.module.scss';
+
+const cx = classNames.bind(style);
+
+interface Option {
+  id: number;
+  option: string;
+}
+
+const initialOption: Option[] = [
+  { id: 1, option: '짜장면' },
+  {
+    id: 2,
+    option: '짬뽕',
+  },
+];
+
+function VoteBlock() {
+  const [options, setOptions] = useState<Option[]>(initialOption);
+  const [isWriting, setIsWriting] = useState<boolean>(true);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onRegister = () => {
+    if (!isWriting) return;
+
+    setIsWriting(false);
+  };
+
+  const onAdd = () => {
+    if (!inputRef.current || !inputRef.current.value) return;
+
+    const { value: option } = inputRef.current;
+
+    const lastId = options.at(-1)?.id;
+    const nextId = lastId !== undefined ? lastId + 1 : 0;
+    const newOption: Option = { id: nextId, option };
+
+    setOptions([...options, newOption]);
+
+    inputRef.current.value = '';
+  };
+
+  const onDelete: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    const { id: targetId } = e.currentTarget.closest('li') as HTMLLIElement;
+
+    const filterdOptions = options.filter(
+      (option) => option.id !== Number(targetId),
+    );
+
+    setOptions(filterdOptions);
+  };
+
+  return (
+    <div className={style['vote-container']}>
+      <h3 className={style.title}>투표</h3>
+      <ul>
+        {options.map(({ id, option }, index) => (
+          <li className={style['option-item']} key={id} id={id.toString()}>
+            <div className={style['box-fill']}>{index + 1}</div>
+            <p className={style.option}>{option}</p>
+            {isWriting && (
+              <div
+                className={cx('box-fill', { 'position-right': true })}
+                onClick={onDelete}
+              >
+                <BiX size="20" />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+      {isWriting && (
+        <>
+          <div className={style['option-item']}>
+            <div className={style['box-fill']}></div>
+            <input
+              ref={inputRef}
+              className={style['option-input']}
+              placeholder="항목을 입력해주세요"
+            ></input>
+          </div>
+          <div className={style['vote-buttons']}>
+            <button className={style.button} onClick={onAdd}>
+              항목 추가
+            </button>
+            <button className={style.button} onClick={onRegister}>
+              투표 등록
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default VoteBlock;

--- a/client/src/components/VoteBlock/index.tsx
+++ b/client/src/components/VoteBlock/index.tsx
@@ -44,9 +44,7 @@ function VoteBlock() {
     inputRef.current.value = '';
   };
 
-  const onDelete: React.MouseEventHandler<HTMLDivElement> = (e) => {
-    const { id: targetId } = e.currentTarget.closest('li') as HTMLLIElement;
-
+  const onDelete = (targetId: number) => {
     const filterdOptions = options.filter(
       (option) => option.id !== Number(targetId),
     );
@@ -65,7 +63,7 @@ function VoteBlock() {
             {isWriting && (
               <div
                 className={cx('box-fill', { 'position-right': true })}
-                onClick={onDelete}
+                onClick={() => onDelete(id)}
               >
                 <BiX size="20" />
               </div>

--- a/client/src/components/VoteBlock/style.module.scss
+++ b/client/src/components/VoteBlock/style.module.scss
@@ -18,7 +18,6 @@
   }
 
   .option-item {
-
     display: flex;
     position: relative;
     flex-direction: row;
@@ -74,7 +73,7 @@
 
     margin-top: 20px;
 
-    .button {
+    button {
       display: flex;
       align-items: center;
       justify-content: center;

--- a/client/src/components/VoteBlock/style.module.scss
+++ b/client/src/components/VoteBlock/style.module.scss
@@ -75,15 +75,23 @@
     margin-top: 20px;
 
     .button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
       width: 100px;
       height: 30px;
-
       margin-left: 12px;
+      padding: 0px;
 
       border-radius: 8px;
 
       background-color: $primary-100;
       color: $white;
+
+      span {
+        padding: 0px;
+      }
     }
   }
 }

--- a/client/src/components/VoteBlock/style.module.scss
+++ b/client/src/components/VoteBlock/style.module.scss
@@ -1,0 +1,89 @@
+@import 'styles/color.module';
+
+.vote-container {
+  width: 100%;
+
+  padding: 20px;
+
+  border-radius: 12px;
+
+  background-color: $white;
+  box-shadow: 1px 4px 12px rgba(0, 0, 0, 0.2);
+
+  .title {
+    font-size: 16px;
+    font-weight: 700;
+
+    text-align: center;
+  }
+
+  .option-item {
+
+    display: flex;
+    position: relative;
+    flex-direction: row;
+    align-items: center;
+
+    width: 100%;
+
+    margin: 14px 0px;
+    padding: 12px;
+
+    border-radius: 12px;
+    box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.2);
+
+    cursor: pointer;
+
+    .box-fill {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      width: 30px;
+      height: 30px;
+
+      margin-right: 12px;
+
+      border-radius: 4px;
+
+      background-color: $primary-100;
+      color: $white;
+
+      font-size: 16px;
+    }
+
+    .option {
+      font-size: 16px;
+      font-weight: 400;
+    }
+
+    .option-input {
+      width: 100%;
+    }
+
+    .position-right {
+      position: absolute;
+      right: 0;
+    }
+  }
+
+  .vote-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+
+    margin-top: 20px;
+
+    .button {
+      width: 100px;
+      height: 30px;
+
+      margin-left: 12px;
+
+      border-radius: 8px;
+
+      background-color: $primary-100;
+      color: $white;
+    }
+  }
+}


### PR DESCRIPTION

## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #147

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

1. 항목 추가, 제거
2. 투표 등록

지금 질문블럭이랑, 투표 블럭 모두 어떤 감싸는 컨테이너와, 타이틀, 아이템들 등등 겹치는 부분이 많아요. 스타일도..! 
이 부분을 뭔가 추상화 시킬 수 있을 것 같은데 지금은 잘 안보여서 나중에 리팩토링 이슈를 달고 한번 해볼게요.

input으로 항목 추가하는 부분은 처음에 state로 들고 있다가 항목 추가 했을 때 그 state값을 사용할 까 했는데 그럼 불필요한 리렌더링이 계속 일어날 것 같아서 state 말고 ref를 붙였어요. 그래서 추가하기 버튼을 클릭했을 때 ref의 value값을 사용해요

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### Q. 컴포넌트가 큰거같나요? 배드스멜이 나시나요? 💩
100줄 정도면 그렇게 큰 느낌은 안드는데 나중에 api 붙이고 하면 뭔가 고생할것 같은..? (관심사 혼잡) 

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/65100540/204453928-56eb0518-f88c-4a08-b512-17e77dc701ca.mov

- `+`종료 버튼 추가

https://user-images.githubusercontent.com/65100540/204479990-acba3725-1183-4371-9823-2498055c66ae.mov

