### PR TITLE
Feat/#145-S : 마이크/캠 on/off 기능

### DIFF
--- a/client/src/components/ConfMediaBar/ConfMedia/index.tsx
+++ b/client/src/components/ConfMediaBar/ConfMedia/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 import style from './style.module.scss';
 
@@ -17,4 +17,4 @@ function ConfMedia({ stream }: MediaProps) {
   return <video className={style.video} ref={ref} autoPlay />;
 }
 
-export default ConfMedia;
+export default memo(ConfMedia);

--- a/client/src/components/ConfMediaBar/StreamButton/CamButton/index.tsx
+++ b/client/src/components/ConfMediaBar/StreamButton/CamButton/index.tsx
@@ -1,0 +1,27 @@
+import { MdVideocam } from '@react-icons/all-files/md/MdVideocam';
+import { MdVideocamOff } from '@react-icons/all-files/md/MdVideocamOff';
+import { Dispatch, SetStateAction } from 'react';
+import color from 'styles/color.module.scss';
+
+interface CamButtonProps {
+  isOn: boolean;
+  setIsCamOn?: Dispatch<SetStateAction<boolean>>;
+}
+
+function CamButton({ isOn, setIsCamOn }: CamButtonProps) {
+  const onClick = () => {
+    if (setIsCamOn) setIsCamOn(!isOn);
+  };
+
+  return (
+    <button onClick={onClick}>
+      {isOn ? (
+        <MdVideocamOff color={color.red} size={20} />
+      ) : (
+        <MdVideocam color={color.green} size={20} />
+      )}
+    </button>
+  );
+}
+
+export default CamButton;

--- a/client/src/components/ConfMediaBar/StreamButton/MicButton/index.tsx
+++ b/client/src/components/ConfMediaBar/StreamButton/MicButton/index.tsx
@@ -1,0 +1,27 @@
+import { MdMic } from '@react-icons/all-files/md/MdMic';
+import { MdMicOff } from '@react-icons/all-files/md/MdMicOff';
+import { Dispatch, SetStateAction } from 'react';
+import color from 'styles/color.module.scss';
+
+interface MicButtonProps {
+  isOn: boolean;
+  setIsMicOn?: Dispatch<SetStateAction<boolean>>;
+}
+
+function MicButton({ isOn, setIsMicOn }: MicButtonProps) {
+  const onClick = () => {
+    if (setIsMicOn) setIsMicOn(!isOn);
+  };
+
+  return (
+    <button onClick={onClick}>
+      {isOn ? (
+        <MdMicOff color={color.red} size={20} />
+      ) : (
+        <MdMic color={color.green} size={20} />
+      )}
+    </button>
+  );
+}
+
+export default MicButton;

--- a/client/src/components/ConfMediaBar/StreamButton/index.tsx
+++ b/client/src/components/ConfMediaBar/StreamButton/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, memo, SetStateAction } from 'react';
 
 import CamButton from './CamButton';
 import MicButton from './MicButton';
@@ -25,4 +25,4 @@ function StreamButton({
   );
 }
 
-export default StreamButton;
+export default memo(StreamButton);

--- a/client/src/components/ConfMediaBar/StreamButton/index.tsx
+++ b/client/src/components/ConfMediaBar/StreamButton/index.tsx
@@ -1,0 +1,28 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import CamButton from './CamButton';
+import MicButton from './MicButton';
+import style from './style.module.scss';
+
+interface StreamButtonProps {
+  isMicOn: boolean;
+  isCamOn: boolean;
+  setIsMicOn?: Dispatch<SetStateAction<boolean>>;
+  setIsCamOn?: Dispatch<SetStateAction<boolean>>;
+}
+
+function StreamButton({
+  isMicOn,
+  isCamOn,
+  setIsMicOn,
+  setIsCamOn,
+}: StreamButtonProps) {
+  return (
+    <div className={style['stream-button']}>
+      <MicButton isOn={isMicOn} setIsMicOn={setIsMicOn} />
+      <CamButton isOn={isCamOn} setIsCamOn={setIsCamOn} />
+    </div>
+  );
+}
+
+export default StreamButton;

--- a/client/src/components/ConfMediaBar/StreamButton/style.module.scss
+++ b/client/src/components/ConfMediaBar/StreamButton/style.module.scss
@@ -1,0 +1,12 @@
+@import 'styles/color.module';
+
+.stream-button {
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  margin: auto;
+  padding: 5px 10px;
+  border-radius: 20px;
+  background-color: $gray-300-transparent;
+  cursor: pointer;
+}

--- a/client/src/components/ConfMediaBar/index.tsx
+++ b/client/src/components/ConfMediaBar/index.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useConfMediaStreams } from 'src/hooks/useConfMediaStreams';
 import useSocket from 'src/hooks/useSocket';
 
 import ConfMedia from './ConfMedia';
+import StreamButton from './StreamButton';
 import style from './style.module.scss';
 
 function ConfMediaBar() {
@@ -10,15 +12,30 @@ function ConfMediaBar() {
   const socket = useSocket(`/signaling/${id}`);
   const streams = useConfMediaStreams(socket);
 
+  const [isMicOn, setIsMicOn] = useState(false);
+  const [isCamOn, setIsCamOn] = useState(false);
+
   return (
     <div className={style['conf-bar']}>
       <ul>
         {Array.from(streams).map(([id, stream]) => (
           <li key={id}>
             <ConfMedia key={id} stream={stream} />
+            <StreamButton
+              isMicOn={false}
+              isCamOn={true} // TODO: 임시로 지정
+            />
           </li>
         ))}
       </ul>
+      <StreamButton
+        {...{
+          isMicOn,
+          isCamOn,
+          setIsMicOn,
+          setIsCamOn,
+        }}
+      />
     </div>
   );
 }

--- a/client/src/components/ConfMediaBar/style.module.scss
+++ b/client/src/components/ConfMediaBar/style.module.scss
@@ -10,12 +10,24 @@
 
   ul {
     height: 100%;
-    padding: 0 10px;
+    padding: 10px;
     overflow: hidden;
     overflow-y: auto;
+
+    li {
+      position: relative;
+      & > div {
+        position: absolute;
+        right: 5px;
+        bottom: 10px;
+      }
+    }
 
     li:not(:last-child) {
       margin-bottom: 10px;
     }
+  }
+  & > div {
+    margin-top: 10px;
   }
 }

--- a/client/src/components/Confbar/index.tsx
+++ b/client/src/components/Confbar/index.tsx
@@ -1,5 +1,0 @@
-function Confbar() {
-  return <div></div>;
-}
-
-export default Confbar;

--- a/client/src/styles/color.module.scss
+++ b/client/src/styles/color.module.scss
@@ -5,6 +5,7 @@ $black: #474747;
 $gray-100: #5c5c5c;
 $gray-200: #bbbbbb;
 $gray-300: #d9d9d9;
+$gray-300-transparent: #d9d9d9a8;
 $red: #cc3b3b;
 $green: #36ba2b;
 $highlight-100: #59c3ff;


### PR DESCRIPTION
## 🤠 개요

- resolve #145
- 마이크/캠 on/off 버튼 만들기

## 💫 설명

- MicButton, CamButton 제작
- `StreamButton`: 위 두개를 합친 하나의 스트림 버튼 제작
- ul 태그 밖에 있는 `StreamButton` 은 내 스트림을 on/off 할 수 있어야 해서 setState를 넣어서 따로 추가했어요
  - 다른 사용자들의 스트림 상태는 isMicOn, isCamOn 으로 색상으로 구분만 돼요 (read-only)
- memo 로 불필요한 렌더링 줄이기

## 🌜 고민거리 (Optional)

### Q. ConfMediaBar에서 StreamButton 스타일을 직접 조정하고 싶은데 저번에 말했던 모듈 스타일 이슈로 일단은 `& > div` 이렇게 StreamButton 스타일을 처리했어요..
- position: absolute 로 카메라의 오른쪽 하단에 배치하기 위해 필요했어요

> ConfMediaBar 에서 className을 넣어주고, StreamButton 에서 classnames의 cx로 조정하려고 했지만, StreamButton의 스타일 모듈에 정의되기 때문에 ConfMediaBar 에서 정의한 StreamButton 스타일이 먹히지 않음

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/63364990/204455987-09299df7-ea2a-43d6-b0ad-c5614e15774c.mov

