### PR TITLE
Fix/#146-K: DB 저장 시에 Object ref 제거

### DIFF
--- a/@wabinar-crdt/index.ts
+++ b/@wabinar-crdt/index.ts
@@ -25,6 +25,13 @@ class CRDT {
     return this.structure;
   }
 
+  get plainData() {
+    // DB에 저장할 때 ref 제거하기 위함
+    const stringifiedData = JSON.stringify(this.structure);
+
+    return JSON.parse(stringifiedData);
+  }
+
   localInsert(index: number, letter: string): RemoteInsertOperation {
     const id = new Identifier(this.clock++, this.client);
 

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -47,14 +47,14 @@ async function momSocketServer(io: Server) {
       socket.broadcast.emit('mom-insertion', op);
       crdt.remoteInsert(op);
 
-      putMom(momId, crdt.data);
+      putMom(momId, crdt.plainData);
     });
 
     socket.on('mom-deletion', async (op) => {
       socket.broadcast.emit('mom-deletion', op);
       crdt.remoteDelete(op);
 
-      putMom(momId, crdt.data);
+      putMom(momId, crdt.plainData);
     });
 
     // 에러 시


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Resolve #146

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

head 참조와 nodeMap에서의 참조가 동일해 MongoDB에서 Circular reference 에러가 발생했어요.
Object ref들을 제거하기 위해서 한번 stringify 했다가 다시 parse 해주는 메서드를 추가해서 사용했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)