### PR TITLE
Feat/#157-K: 사이드바 기능 연동

### DIFF
--- a/client/src/components/Sidebar/MemberList.tsx
+++ b/client/src/components/Sidebar/MemberList.tsx
@@ -1,28 +1,23 @@
+import { TUser } from 'src/types/user';
+
 import style from './style.module.scss';
 
-function MemberList() {
-  const members = [
-    {
-      id: 1,
-      name: '백도훈',
-      avatarUrl: 'https://avatars.githubusercontent.com/u/65100540?s=60&v=4',
-    },
-    {
-      id: 2,
-      name: '백도훈',
-      avatarUrl: 'https://avatars.githubusercontent.com/u/65100540?s=60&v=4',
-    },
-  ];
+interface MemberListProps {
+  members: TUser[];
+}
 
+function MemberList({ members }: MemberListProps) {
   return (
-    <ul className={style['member-list']}>
-      {members.map((item) => (
-        <li key={item.id} className={style['member-item']}>
-          <img src={item.avatarUrl} />
-          <span>{item.name}</span>
-        </li>
-      ))}
-    </ul>
+    members && (
+      <ul className={style['member-list']}>
+        {members.map((item) => (
+          <li key={item.id} className={style['member-item']}>
+            <img src={item.avatarUrl} />
+            <span>{item.name}</span>
+          </li>
+        ))}
+      </ul>
+    )
   );
 }
 

--- a/client/src/components/Sidebar/MemberList.tsx
+++ b/client/src/components/Sidebar/MemberList.tsx
@@ -8,16 +8,14 @@ interface MemberListProps {
 
 function MemberList({ members }: MemberListProps) {
   return (
-    members && (
-      <ul className={style['member-list']}>
-        {members.map((item) => (
-          <li key={item.id} className={style['member-item']}>
-            <img src={item.avatarUrl} />
-            <span>{item.name}</span>
-          </li>
-        ))}
-      </ul>
-    )
+    <ul className={style['member-list']}>
+      {members.map((item) => (
+        <li key={item.id} className={style['member-item']}>
+          <img src={item.avatarUrl} />
+          <span>{item.name}</span>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,18 +1,18 @@
+import { TMom } from 'src/types/mom';
+
 import style from './style.module.scss';
 
-function MomList() {
-  const moms = [
-    { id: 1, name: '회의록 1' },
-    { id: 2, name: '회의록 2' },
-    { id: 3, name: '회의록 3' },
-  ];
+interface MomListProps {
+  moms: TMom[];
+}
 
+function MomList({ moms }: MomListProps) {
   return (
     <div className={style['mom-list-container']}>
       <h2>회의록</h2>
       <ul className={style['mom-list']}>
         {moms.map((item) => (
-          <li key={item.id}>{item.name}</li>
+          <li key={item._id}>{item._id}</li>
         ))}
       </ul>
       <button>+ 회의록 추가</button>

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from 'react';
+import useSocketContext from 'src/hooks/useSocketContext';
 import { TMom } from 'src/types/mom';
 
 import style from './style.module.scss';
@@ -7,15 +9,37 @@ interface MomListProps {
 }
 
 function MomList({ moms }: MomListProps) {
+  const { momSocket: socket } = useSocketContext();
+
+  const [momList, setMomList] = useState<TMom[]>(moms);
+
+  const onCreateMom = () => {
+    socket.emit('create-mom');
+  };
+
+  useEffect(() => {
+    socket.on('created-mom', (mom) => setMomList((prev) => [...prev, mom]));
+    // TODO: socket.on('selected-mom', () => {});
+
+    return () => {
+      socket.off('created-mom');
+    };
+  }, []);
+
   return (
     <div className={style['mom-list-container']}>
       <h2>회의록</h2>
       <ul className={style['mom-list']}>
-        {moms.map((item) => (
-          <li key={item._id}>{item._id}</li>
+        {momList.map((item) => (
+          <li
+            key={item._id}
+            onClick={() => socket.emit('select-mom', item._id)}
+          >
+            {item._id}
+          </li>
         ))}
       </ul>
-      <button>+ 회의록 추가</button>
+      <button onClick={onCreateMom}>+ 회의록 추가</button>
     </div>
   );
 }

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -1,18 +1,24 @@
+import { WorkspaceInfo } from 'src/types/workspace';
+
 import ConfButton from './ConfButton';
 import MemberList from './MemberList';
 import MomList from './MomList';
 import SettingIcon from './SettingIcon';
 import style from './style.module.scss';
 
-function Sidebar() {
+interface SidebarProps {
+  workspace: WorkspaceInfo;
+}
+
+function Sidebar({ workspace }: SidebarProps) {
   return (
     <div className={style['sidebar-container']}>
       <div className={style['header']}>
         <h1>왭^^</h1>
         <SettingIcon />
       </div>
-      <MemberList />
-      <MomList />
+      <MemberList members={workspace.members} />
+      <MomList moms={workspace.moms} />
       <ConfButton />
     </div>
   );

--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -24,7 +24,7 @@ function Workspace({ workspaceId }: WorkspaceProps) {
   return (
     workspace && (
       <>
-        <Sidebar />
+        <Sidebar workspace={workspace} />
         <Mom />
       </>
     )

--- a/client/src/types/mom.d.ts
+++ b/client/src/types/mom.d.ts
@@ -1,4 +1,4 @@
 export type TMom = {
-  id: number;
+  _id: number;
   name: string;
 };

--- a/server/apis/workspace/service.test.ts
+++ b/server/apis/workspace/service.test.ts
@@ -134,7 +134,7 @@ describe('info', () => {
 
     expect(workspaceService.info(WORKSPACE_ID)).resolves.toEqual({
       name: WORKSPACE_NAME,
-      users: [],
+      members: [],
       moms: [],
     });
   });

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -51,7 +51,7 @@ export const info = async (workspaceId: number) => {
 
   const { name, users: userIds, moms: momsIds } = workspace;
 
-  const users: Pick<User, 'id' | 'name' | 'avatarUrl'>[] =
+  const members: Pick<User, 'id' | 'name' | 'avatarUrl'>[] =
     (await userModel.find(
       {
         id: { $in: userIds },
@@ -62,5 +62,5 @@ export const info = async (workspaceId: number) => {
   const moms: string[] =
     (await momModel.find({ id: { $in: momsIds } }, { name: 1 })) || [];
 
-  return { name, users, moms };
+  return { name, members, moms };
 };


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Close #157 

getWorkspaceInfo로 받아온 정보를 사이드바에 넣어주고 회의록 생성, 선택 기능을 연동했어요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- API로 받아온 정보가 표시될 수 있게 했어요.
  워크스페이스에 가입된 유저 정보가 users로 되어있어 members로 수정했어요.

- 회의록 추가와 선택 기능을 소켓 서버와 연동했어요.
  선택된 회의록 컨텍스트를 만들고 `on('selected-mom')`에 업데이트 해줘야해요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)