### PR TITLE
Feat/#160-S : 투표 생성, 수정 API 작성

### DIFF
--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -50,7 +50,7 @@ export const stopVote = (momId: number) => {
   votes[momId].isDoing = false;
 
   const participantNum = votes[momId].options.reduce(
-    (acc, { votedNum }) => acc + votedNum,
+    (acc, { count }) => acc + count,
     0,
   );
 

--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -23,6 +23,10 @@ export const createVote = (momId: number, vote: Vote) => {
 
 export const updateVote = (momId: number, optionId: number) => {
   const vote = votes[momId];
+  if (!vote) return;
+
+  const option = vote.options.filter(({ id }) => optionId === id);
+  if (!option.length) return;
 
   vote.options = vote.options.map((option) => {
     const { id, votedNum } = option;

--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -25,8 +25,8 @@ export const updateVote = (momId: number, optionId: number) => {
   const vote = votes[momId];
   if (!vote) return;
 
-  const option = vote.options.filter(({ id }) => optionId === id);
-  if (!option.length) return;
+  const isExist = vote.options.some(({ id }) => optionId === id);
+  if (!isExist) return;
 
   vote.options = vote.options.map((option) => {
     const { id, votedNum } = option;

--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -1,7 +1,7 @@
 interface Option {
   id: number;
   option: string;
-  votedNum: number;
+  count: number;
 }
 
 interface Vote {
@@ -29,10 +29,10 @@ export const updateVote = (momId: number, optionId: number) => {
   if (!isExist) return;
 
   vote.options = vote.options.map((option) => {
-    const { id, votedNum } = option;
+    const { id, count } = option;
 
     if (id === optionId) {
-      return { ...option, votedNum: votedNum + 1 };
+      return { ...option, count: count + 1 };
     }
     return option;
   });

--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -1,0 +1,37 @@
+interface Option {
+  id: number;
+  option: string;
+  votedNum: number;
+}
+
+interface Vote {
+  _id: string;
+  title: string;
+  options: Option[];
+}
+
+interface Votes {
+  [id: string]: Vote;
+}
+
+const votes: Votes = {};
+
+export const createVote = (momId: number, vote: Vote) => {
+  votes[momId] = vote;
+  return votes[momId];
+};
+
+export const updateVote = (momId: number, optionId: number) => {
+  const vote = votes[momId];
+
+  vote.options = vote.options.map((option) => {
+    const { id, votedNum } = option;
+
+    if (id === optionId) {
+      return { ...option, votedNum: votedNum + 1 };
+    }
+    return option;
+  });
+
+  return vote.options;
+};

--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -1,6 +1,6 @@
 interface Option {
   id: number;
-  option: string;
+  text: string;
   count: number;
 }
 
@@ -8,6 +8,7 @@ interface Vote {
   _id: string;
   title: string;
   options: Option[];
+  isDoing: boolean;
 }
 
 interface Votes {
@@ -17,7 +18,7 @@ interface Votes {
 const votes: Votes = {};
 
 export const createVote = (momId: number, vote: Vote) => {
-  votes[momId] = vote;
+  votes[momId] = { ...vote, isDoing: true };
   return votes[momId];
 };
 
@@ -38,4 +39,20 @@ export const updateVote = (momId: number, optionId: number) => {
   });
 
   return vote.options;
+};
+
+export const stopVote = (momId: number) => {
+  const vote = votes[momId];
+  if (!vote) return { message: '존재하지 않는 투표입니다 ^^' };
+
+  if (!votes[momId].isDoing) return { message: '이미 종료된 투표입니다 ^^' };
+
+  votes[momId].isDoing = false;
+
+  const participantNum = votes[momId].options.reduce(
+    (acc, { votedNum }) => acc + votedNum,
+    0,
+  );
+
+  return { vote, participantNum };
 };

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -102,12 +102,14 @@ async function momSocketServer(io: Server) {
     /* 투표 관련 이벤트 */
     socket.on('create-vote', (momId, vote) => {
       const newVote = createVote(momId, vote);
-      workspace.emit('created-mom', newVote);
+      workspace.emit('created-vote', newVote);
     });
 
     socket.on('update-vote', (momId, optionId) => {
-      updateVote(momId, Number(optionId));
-      socket.emit('updated-vote', '투표 성공');
+      const res = updateVote(momId, Number(optionId));
+      const message = res ? '투표 성공' : '투표 실패';
+
+      socket.emit('updated-vote', message);
     });
 
     socket.on('error', (err) => {

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -1,7 +1,8 @@
 import { createMom, getMom, putMom } from '@apis/mom/service';
+import { createVote, updateVote } from '@apis/mom/vote/service';
 import CRDT from '@wabinar/crdt';
-import { Server } from 'socket.io';
 import LinkedList from '@wabinar/crdt/linked-list';
+import { Server } from 'socket.io';
 
 async function momSocketServer(io: Server) {
   const workspace = io.of(/^\/sc-workspace\/\d+$/);
@@ -96,6 +97,17 @@ async function momSocketServer(io: Server) {
       crdt.remoteDelete(op);
 
       putMom(momId, crdt.plainData);
+    });
+
+    /* 투표 관련 이벤트 */
+    socket.on('create-vote', (momId, vote) => {
+      const newVote = createVote(momId, vote);
+      workspace.emit('created-mom', newVote);
+    });
+
+    socket.on('update-vote', (momId, optionId) => {
+      updateVote(momId, Number(optionId));
+      socket.emit('updated-vote', '투표 성공');
     });
 
     socket.on('error', (err) => {

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -1,5 +1,5 @@
 import { createMom, getMom, putMom } from '@apis/mom/service';
-import { createVote, updateVote } from '@apis/mom/vote/service';
+import { createVote, stopVote, updateVote } from '@apis/mom/vote/service';
 import CRDT from '@wabinar/crdt';
 import LinkedList from '@wabinar/crdt/linked-list';
 import { Server } from 'socket.io';
@@ -110,6 +110,11 @@ async function momSocketServer(io: Server) {
       const message = res ? '투표 성공' : '투표 실패';
 
       socket.emit('updated-vote', message);
+    });
+
+    socket.on('stop-vote', (momId) => {
+      const res = stopVote(momId);
+      workspace.emit('stoped-vote', res);
     });
 
     socket.on('error', (err) => {


### PR DESCRIPTION
## 🤠 개요

- resolve #160 
- 투표 생성하기와 투표하기 API를 만들었어요

## 💫 설명

- DB 사용하지 말라고 해서 일단 vote 객체로 관리하게 두었어요
  - DB로 변경하면 momId에 해당하는 회의록 가져오는 부분이랑 투표 insert, update 하는 거 추가하면 될 거 같아요
- 생성은 회의록 Id와 생성한 vote를 인자로 넘겨주면 돼요
- 투표하기는 회의록 Id와 투표한 option의 id를 넘겨주면 돼요
  - 투표 후에는 딱히 전달해줄 값이 없어서 투표 성공 메세지만 넣었어요
- 예외처리는 momId가 없을 경우, optionId가 없을 경우로 나눴는데, 서버에서 아예 오류를 뱉으면 서버가 멈춰서 투표 성공, 실패 여부를 반환하는 거로 했어요

## 🌜 고민거리 (Optional)

## 📷 스크린샷 (Optional)
- postman 테스트
![스크린샷 2022-11-30 오후 3 54 39](https://user-images.githubusercontent.com/63364990/204728172-1714abb0-6cee-4f2b-9779-78a1c548d5bb.png)

- 하나씩 투표되는 거 서버로그에 찍어보기
![스크린샷 2022-11-30 오후 2 54 39](https://user-images.githubusercontent.com/63364990/204723595-fe5ad39d-d559-4fa2-b5e1-34658205e967.png)
