### PR TITLE
Feat/#165-B: 워크스페이스 변경

### DIFF
--- a/client/src/components/Mom/index.tsx
+++ b/client/src/components/Mom/index.tsx
@@ -1,13 +1,19 @@
-import useMom from 'src/hooks/useSelectedMom';
+import useSelectedMom from 'src/hooks/useSelectedMom';
 
 import Editor from '../Editor';
 import style from './style.module.scss';
 
 function Mom() {
-  const { selectedMom } = useMom();
+  const { selectedMom } = useSelectedMom();
 
   if (!selectedMom) {
-    return <h1>아직 회의록이 없어요. 만들어 보세요^^</h1>;
+    return (
+      <div className={style['mom-container']}>
+        <div className={style['mom']}>
+          <h1>아직 회의록이 없어요. 만들어 보세요^^</h1>
+        </div>
+      </div>
+    );
   }
   // context나 props로 가져오기
 

--- a/client/src/components/Mom/index.tsx
+++ b/client/src/components/Mom/index.tsx
@@ -36,17 +36,23 @@ function Mom() {
   return (
     <div className={style['mom-container']}>
       <div className={style['mom']}>
-        <div className={style['mom-header']}>
-          <h1
-            contentEditable={true}
-            suppressContentEditableWarning={true}
-            onInput={onTitleChange}
-          >
-            {selectedMom._id}
-          </h1>
-          <span>{new Date().toLocaleString()}</span>
-        </div>
-        <Editor />
+        {selectedMom ? (
+          <>
+            <div className={style['mom-header']}>
+              <h1
+                contentEditable={true}
+                suppressContentEditableWarning={true}
+                onInput={onTitleChange}
+              >
+                {selectedMom._id}
+              </h1>
+              <span>{new Date().toLocaleString()}</span>
+            </div>
+            <Editor />
+          </>
+        ) : (
+          <h1>아직 회의록이 없어요. 만들어 보세요^^</h1>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import useMom from 'src/hooks/useSelectedMom';
 import useSocketContext from 'src/hooks/useSocketContext';
 import { TMom } from 'src/types/mom';
@@ -20,11 +21,12 @@ function MomList({ moms }: MomListProps) {
 
   const onSelect = (targetId: string) => {
     if (selectedMom && selectedMom._id === targetId) return;
-
     socket.emit('select-mom', targetId);
   };
 
   useEffect(() => {
+    setMomList(moms);
+
     socket.on('created-mom', (mom) => setMomList((prev) => [...prev, mom]));
 
     socket.on('selected-mom', (mom) => {
@@ -33,8 +35,9 @@ function MomList({ moms }: MomListProps) {
 
     return () => {
       socket.off('created-mom');
+      socket.off('selected-mom');
     };
-  }, []);
+  }, [moms]);
 
   return (
     <div className={style['mom-list-container']}>

--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -16,7 +16,7 @@ function Workspace({ workspaceId }: WorkspaceProps) {
 
   useEffect(() => {
     loadWorkspaceInfo();
-  }, []);
+  }, [workspaceId]);
 
   const loadWorkspaceInfo = async () => {
     if (workspaceId) {
@@ -26,6 +26,8 @@ function Workspace({ workspaceId }: WorkspaceProps) {
       // 제일 처음 입장했을 때 defalult 회의록 보여주기
       if (workspaceInfo.moms.length) {
         setSelectedMom(workspaceInfo.moms[0]);
+      } else {
+        setSelectedMom(null);
       }
     }
   };

--- a/client/src/components/WorkspaceThumbnailList/WorkspaceThumbnailItem.tsx
+++ b/client/src/components/WorkspaceThumbnailList/WorkspaceThumbnailItem.tsx
@@ -5,14 +5,18 @@ import style from './style.module.scss';
 interface WorkspaceThumbnailItemProps {
   name: string;
   imageUrl?: string;
+  onClick: () => void;
 }
 
 /**
  * API 연동할 때 변경해줘야 해요.
  */
-function WorkspaceThumbnailItem({ name }: WorkspaceThumbnailItemProps) {
+function WorkspaceThumbnailItem({
+  name,
+  onClick,
+}: WorkspaceThumbnailItemProps) {
   return (
-    <li className={style.thumbnail}>
+    <li className={style.thumbnail} onClick={onClick}>
       <div className={style.thumbnail__content}>
         {/* <img src={imageUrl} /> */}
         {name[0]}

--- a/client/src/components/WorkspaceThumbnailList/index.tsx
+++ b/client/src/components/WorkspaceThumbnailList/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Workspace } from 'src/types/workspace';
 
 import style from './style.module.scss';
@@ -8,10 +9,20 @@ interface WorkspaceThumbnailListProps {
 }
 
 function WorkspaceThumbnailList({ workspaces }: WorkspaceThumbnailListProps) {
+  const navigate = useNavigate();
+
+  const onClick = (targetId: number) => {
+    navigate(`/workspace/${targetId}`);
+  };
+
   return (
     <ul className={style.thumbnail__list}>
-      {workspaces.map((workspace) => (
-        <WorkspaceThumbnailItem key={workspace.id} name={workspace.name} />
+      {workspaces.map(({ id, name }) => (
+        <WorkspaceThumbnailItem
+          key={id}
+          name={name}
+          onClick={() => onClick(id)}
+        />
       ))}
     </ul>
   );

--- a/server/apis/mom/model.ts
+++ b/server/apis/mom/model.ts
@@ -1,17 +1,27 @@
 import mongoose from '@db';
 import { Schema } from 'mongoose';
 import LinkedList from '@wabinar/crdt/linked-list';
+import autoIncrement from 'mongoose-auto-increment';
 
 interface Mom extends LinkedList {
+  id: number;
   name: string;
   createdAt: Date;
 }
 
 const momSchema = new Schema<Mom>({
+  id: { type: Number, required: true },
   name: { type: String, default: '제목 없음' },
   createdAt: { type: Date, default: new Date() },
   head: { type: Object, default: null },
   nodeMap: { type: Object, default: {} },
+});
+
+momSchema.plugin(autoIncrement.plugin, {
+  model: 'mom',
+  field: 'id',
+  startAt: 1,
+  increment: 1,
 });
 
 const momModel = mongoose.model('Mom', momSchema);

--- a/server/apis/mom/service.ts
+++ b/server/apis/mom/service.ts
@@ -1,3 +1,5 @@
+import workspaceModel from '@apis/workspace/model';
+import { info } from '@apis/workspace/service';
 import LinkedList from '@wabinar/crdt/linked-list';
 import momModel from './model';
 
@@ -7,8 +9,14 @@ export const getMom = async (id: string) => {
   return mom;
 };
 
-export const createMom = async () => {
+export const createMom = async (workspaceId: string) => {
   const mom = await momModel.create({});
+
+  await workspaceModel.updateOne(
+    { id: workspaceId },
+    { $addToSet: { moms: mom.id } },
+  );
+
   return mom;
 };
 

--- a/server/apis/workspace/model.ts
+++ b/server/apis/workspace/model.ts
@@ -17,6 +17,7 @@ const workspaceSchema = new Schema<Workspace>({
   users: { type: [Number], default: [] },
   moms: { type: [Number], default: [] },
 });
+
 workspaceSchema.plugin(autoIncrement.plugin, {
   model: 'workspace',
   field: 'id',

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -59,7 +59,7 @@ export const info = async (workspaceId: number) => {
       { id: 1, name: 1, avatarUrl: 1, _id: 0 },
     )) || [];
 
-  const moms: string[] = momsIds
+  const moms: string[] = momsIds.length
     ? await momModel.find({ id: { $in: momsIds } }, { name: 1 })
     : [];
 

--- a/server/apis/workspace/service.ts
+++ b/server/apis/workspace/service.ts
@@ -59,8 +59,9 @@ export const info = async (workspaceId: number) => {
       { id: 1, name: 1, avatarUrl: 1, _id: 0 },
     )) || [];
 
-  const moms: string[] =
-    (await momModel.find({ id: { $in: momsIds } }, { name: 1 })) || [];
+  const moms: string[] = momsIds
+    ? await momModel.find({ id: { $in: momsIds } }, { name: 1 })
+    : [];
 
   return { name, members, moms };
 };

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -29,7 +29,7 @@ async function momSocketServer(io: Server) {
 
     /* 회의록 추가하기 */
     socket.on('create-mom', async () => {
-      const mom = await createMom();
+      const mom = await createMom(workspaceId);
       const { _id, head, nodeMap } = mom;
 
       momMap.set(
@@ -64,7 +64,7 @@ async function momSocketServer(io: Server) {
           new CRDT(1, -1, { head, nodeMap } as LinkedList),
         );
       }
-
+      console.log(mom);
       // 선택된 회의록의 정보 전달
       socket.emit('selected-mom', mom);
     });

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -64,7 +64,7 @@ async function momSocketServer(io: Server) {
           new CRDT(1, -1, { head, nodeMap } as LinkedList),
         );
       }
-      console.log(mom);
+
       // 선택된 회의록의 정보 전달
       socket.emit('selected-mom', mom);
     });


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #165 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->
- 워크스페이스 썸네일을 클릭해 현재 워크스페이스를 변경할 수 있어요.

- 이렇게 하면 momsIds가 빈배열이면 그냥 모든 moms를 다 가져오더라구요. (잘 모름. 일단 그렇더라구요. 공식문서 찾아볼게요)
```ts
const moms: string[] =
    (await momModel.find({ id: { $in: momsIds } }, { name: 1 })) || [];
```
- 그래서 이렇게 변경했어요. 
```ts
  const moms: string[] = momsIds
    ? await momModel.find({ id: { $in: momsIds } }, { name: 1 })
    : [];
```

그리고 momsIds를 사용하려면 원래 MomModel에 있던 id 필드를 제거해서 _id를 사용해야하는데 얘는 string도 아니고 number도 아니고 ObjectId라는 타입이더라구요. 그래서 다시 `id: number` 필드 만들어서 사용하고 있어요.

**`+`** test 오류나서 CI가 실패했어요.
  - 해결: [065d046](https://github.com/boostcampwm-2022/web27-Wabinar/pull/170/commits/065d0466535e9533dce4109998b7111921bb30ca)

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### Q. `client/src/components/Sidebar/MomList.tsx`에서 useEffect의 dependency array로 moms를 줬어요. 

- moms를 안줬을 때 아무리 소켓 이벤트를 보내도 받질 않더라구요. 
  - 아무리 `select-mom`이벤트를 보내도 `selected-mom`이벤트가 안와요.
  - network탭에선 socket이벤트가 잘 오는데 리액트까지 안와요. 저번이랑 비슷한 문제에요.
- 제 뇌피셜론 워크스페이스가 변경되면 socket 경로도 변경되는데 `/sc-workspace/:id` useEffect에서 event를 on하고 있는 socket은 워크스페이스가 변경되기 전의 소켓에 연결되어 있어서 그런것 같아요.
- moms를 주고나면 워크스페이스가 변경될 때 마다 바뀐 워크스페이스에 연결하게 돼서 잘되는것 같아요.

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/65100540/204733790-05290571-eab0-4416-8e67-67c50a2b6c09.mov

