### PR TITLE
Feat/#167-S : 투표 종료 소켓 이벤트 작성

### DIFF
--- a/server/apis/mom/vote/service.ts
+++ b/server/apis/mom/vote/service.ts
@@ -1,6 +1,6 @@
 interface Option {
   id: number;
-  option: string;
+  text: string;
   votedNum: number;
 }
 
@@ -8,6 +8,7 @@ interface Vote {
   _id: string;
   title: string;
   options: Option[];
+  isDoing: boolean;
 }
 
 interface Votes {
@@ -17,7 +18,7 @@ interface Votes {
 const votes: Votes = {};
 
 export const createVote = (momId: number, vote: Vote) => {
-  votes[momId] = vote;
+  votes[momId] = { ...vote, isDoing: true };
   return votes[momId];
 };
 
@@ -38,4 +39,20 @@ export const updateVote = (momId: number, optionId: number) => {
   });
 
   return vote.options;
+};
+
+export const stopVote = (momId: number) => {
+  const vote = votes[momId];
+  if (!vote) return { message: '존재하지 않는 투표입니다 ^^' };
+
+  if (!votes[momId].isDoing) return { message: '이미 종료된 투표입니다 ^^' };
+
+  votes[momId].isDoing = false;
+
+  const participantNum = votes[momId].options.reduce(
+    (acc, { votedNum }) => acc + votedNum,
+    0,
+  );
+
+  return { vote, participantNum };
 };

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -3,6 +3,7 @@ import { createVote, updateVote } from '@apis/mom/vote/service';
 import CRDT from '@wabinar/crdt';
 import LinkedList from '@wabinar/crdt/linked-list';
 import { Server } from 'socket.io';
+import { stopVote } from './../apis/mom/vote/service';
 
 async function momSocketServer(io: Server) {
   const workspace = io.of(/^\/sc-workspace\/\d+$/);
@@ -110,6 +111,11 @@ async function momSocketServer(io: Server) {
       const message = res ? '투표 성공' : '투표 실패';
 
       socket.emit('updated-vote', message);
+    });
+
+    socket.on('stop-vote', (momId) => {
+      const res = stopVote(momId);
+      workspace.emit('stoped-vote', res);
     });
 
     socket.on('error', (err) => {

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -1,9 +1,8 @@
 import { createMom, getMom, putMom } from '@apis/mom/service';
-import { createVote, updateVote } from '@apis/mom/vote/service';
+import { createVote, stopVote, updateVote } from '@apis/mom/vote/service';
 import CRDT from '@wabinar/crdt';
 import LinkedList from '@wabinar/crdt/linked-list';
 import { Server } from 'socket.io';
-import { stopVote } from './../apis/mom/vote/service';
 
 async function momSocketServer(io: Server) {
   const workspace = io.of(/^\/sc-workspace\/\d+$/);


### PR DESCRIPTION
## 🤠 개요

- resolve #167 
- 투표 종료 소켓 이벤트 작성

## 💫 설명
- `isDoing` 필드를 추가해서 진행 중인지 아닌지 boolean값으로 구분해요
- 반환 값에 `message` 필드를 추가했어요. 프론트에서 에러 메세지 바로 띄워줘도 좋을 거 같아요
  - 다른 API 들도 예외 처리를 이런 식으로 하는 거 어떨까요.
  - 프론트에서 요청이 원하는 대로 됐는지 아닌지 바로 판단할 수 있게 `{ ok: true or false, message: "" }` ok필드를 추가해줘도 괜찮을 거 같아요
- `participantNum` (참여자 수)를 구해서 프론트에서 바로 참가자 인원 수 표시할 수 있도록 했어요
- `stop-vote` 소켓 이벤트 작성

## 🌜 고민거리 (Optional)


## 📷 스크린샷 (Optional)
- 누군가 종료하면 투표 결과를 반환해요 API docs도 곧 작성할게요
- 누군가 이미 종료했으면 이미 종료된 투표라고 메세지가 와요
![스크린샷 2022-11-30 오후 4 51 14](https://user-images.githubusercontent.com/63364990/204740454-11d8d329-d9ca-4772-be62-c58e536fd93f.png)
