### PR TITLE
Fix/#175-S: 소켓 커넥션이 여러번 생성되는 이슈 해결

### DIFF
--- a/client/src/components/ConfMediaBar/index.tsx
+++ b/client/src/components/ConfMediaBar/index.tsx
@@ -1,15 +1,13 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { useConfMediaStreams } from 'src/hooks/useConfMediaStreams';
-import useSocket from 'src/hooks/useSocket';
+import useSocketContext from 'src/hooks/useSocketContext';
 
 import ConfMedia from './ConfMedia';
 import StreamButton from './StreamButton';
 import style from './style.module.scss';
 
 function ConfMediaBar() {
-  const { id } = useParams();
-  const socket = useSocket(`/signaling/${id}`);
+  const { signalingSocket: socket } = useSocketContext();
   const streams = useConfMediaStreams(socket);
 
   const [isMicOn, setIsMicOn] = useState(false);

--- a/client/src/contexts/socket.ts
+++ b/client/src/contexts/socket.ts
@@ -3,6 +3,7 @@ import { Socket } from 'socket.io-client';
 
 interface ISocketContext {
   momSocket: Socket;
+  signalingSocket: Socket;
 }
 
 export const SocketContext = createContext<ISocketContext | null>(null);

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -13,8 +13,8 @@ function WorkspacePage() {
   const { id } = useParams();
   const [isStart, setIsStart] = useState(false);
 
-  const momSocket = useMemo(() => useSocket(`/sc-workspace/${id}`), []);
-  const signalingSocket = useMemo(() => useSocket(`/signaling/${id}`), []);
+  const momSocket = useMemo(() => useSocket(`/sc-workspace/${id}`), [id]);
+  const signalingSocket = useMemo(() => useSocket(`/signaling/${id}`), [id]);
 
   useEffect(() => {
     momSocket.on('started-mom', () => {

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -1,6 +1,6 @@
 import Workspace from 'components/Workspace';
 import WorkspaceList from 'components/WorkspaceList';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import ConfMediaBar from 'src/components/ConfMediaBar';
 import ConfContext from 'src/contexts/conf';
@@ -13,7 +13,8 @@ function WorkspacePage() {
   const { id } = useParams();
   const [isStart, setIsStart] = useState(false);
 
-  const momSocket = useSocket(`/sc-workspace/${id}`);
+  const momSocket = useMemo(() => useSocket(`/sc-workspace/${id}`), []);
+  const signalingSocket = useMemo(() => useSocket(`/signaling/${id}`), []);
 
   useEffect(() => {
     momSocket.on('started-mom', () => {
@@ -26,7 +27,7 @@ function WorkspacePage() {
   }, []);
 
   return (
-    <SocketContext.Provider value={{ momSocket }}>
+    <SocketContext.Provider value={{ momSocket, signalingSocket }}>
       <ConfContext.Provider value={{ isStart, setIsStart }}>
         <div className={style.container}>
           <WorkspaceList />


### PR DESCRIPTION
## 🤠 개요

- resolve #175 
- 소켓 커넥션이 여러번 생성되는 이슈 해결


## 💫 설명

- isStart라는 상태가 변하게 되면서 워크스페이스 페이지가 다시 렌더링돼요
- 그래서 useSocket으로 생성해주었던 소켓 커넥션이 재생성되게 돼요
- -> `useMemo`를 사용해서 소켓을 메모이제이션 해주었어요

## 🌜 고민거리 (Optional)

## 📷 스크린샷 (Optional)
- 콘솔 에러는 카메라 마이크 거부해서 그래요 ..^^
- 회의 시작 종료에는 커넥션이 안생기고, 다른 워크스페이스 페이지 들어가면 새 커넥션 생성

https://user-images.githubusercontent.com/63364990/204949211-5b7866d3-ba7c-410e-aa83-daa6cee155d6.mov

