### PR TITLE
Refactor/#178-C: 환경 변수로 분리

### DIFF
--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -13,4 +13,6 @@ export default {
   GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   CLIENT_PATH: process.env.CLIENT_PATH,
+  PORT: process.env.PORT,
+  SOCKET_PATH: process.env.WEBSOCKET_PATH,
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,7 +29,7 @@ const io = new Server({
   cors: {
     origin: env.CLIENT_PATH,
   },
-  path: '/ws', // TODO: '/ws' 환경 변수로 분리 필요
+  path: env.SOCKET_PATH,
 });
 
 momSocketServer(io);
@@ -37,4 +37,6 @@ signalingSocketServer(io);
 
 io.attach(server);
 
-server.listen(8080); // TODO: 서버 포트 환경 변수로 분리 필요
+server.listen(env.PORT, () => {
+  console.log(`Server listening on port ${env.PORT}`);
+});


### PR DESCRIPTION
## 🤠 개요

- resolves #178 

## 💫 설명

리터럴로 쓰던 값을 환경 변수로 분리했습니다.

소켓 path나 백엔드 포트를 env에서 컨트롤합니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)