### PR TITLE
Fix/#179-C: 스택 트레이스 에러 메시지에서 삭제

### DIFF
--- a/server/middlewares/error-handler.ts
+++ b/server/middlewares/error-handler.ts
@@ -1,13 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 
 export default (err: any, req: Request, res: Response, next: NextFunction) => {
-  console.log(err);
+  console.error(err);
 
   const message = err.message || 'Internal Server Error';
   const status = err.status || 500;
 
-  res.status(status).send({
-    message,
-    stack: err.stack,
-  });
+  res.status(status).send(message);
 };


### PR DESCRIPTION
## 🤠 개요

- resolves #179

## 💫 설명

응답 메시지에서 보안상 이유로 스택 트레이스를 지웠습니다. (#179 참고)

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)