### PR TITLE
Refactor/#182-B: 회의록 선택시 불필요한 리렌더링 방지

### DIFF
--- a/client/src/components/Sidebar/ConfButton.tsx
+++ b/client/src/components/Sidebar/ConfButton.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useConfContext } from 'src/hooks/useConfContext';
 import useSocketContext from 'src/hooks/useSocketContext';
 import color from 'styles/color.module.scss';
@@ -26,4 +27,4 @@ function ConfButton() {
   );
 }
 
-export default ConfButton;
+export default memo(ConfButton);

--- a/client/src/components/Sidebar/Header.tsx
+++ b/client/src/components/Sidebar/Header.tsx
@@ -1,0 +1,19 @@
+import React, { memo } from 'react';
+
+import SettingIcon from './SettingIcon';
+import style from './style.module.scss';
+
+interface HeaderProps {
+  name: string;
+}
+
+function Header({ name }: HeaderProps) {
+  return (
+    <div className={style['header']}>
+      <h1>{name}</h1>
+      <SettingIcon />
+    </div>
+  );
+}
+
+export default memo(Header);

--- a/client/src/components/Sidebar/MemberList.tsx
+++ b/client/src/components/Sidebar/MemberList.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { TUser } from 'src/types/user';
 
 import style from './style.module.scss';
@@ -19,4 +20,4 @@ function MemberList({ members }: MemberListProps) {
   );
 }
 
-export default MemberList;
+export default memo(MemberList);

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo, useMemo, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import useSelectedMom from 'src/hooks/useSelectedMom';
 import useSocketContext from 'src/hooks/useSocketContext';
 import { TMom } from 'src/types/mom';

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import useMom from 'src/hooks/useSelectedMom';
+import { useState, useEffect, memo, useMemo, useCallback } from 'react';
+import useSelectedMom from 'src/hooks/useSelectedMom';
 import useSocketContext from 'src/hooks/useSocketContext';
 import { TMom } from 'src/types/mom';
 
@@ -11,7 +10,7 @@ interface MomListProps {
 }
 
 function MomList({ moms }: MomListProps) {
-  const { selectedMom, setSelectedMom } = useMom();
+  const { selectedMom, setSelectedMom } = useSelectedMom();
   const { momSocket: socket } = useSocketContext();
   const [momList, setMomList] = useState<TMom[]>(moms);
 

--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import useSelectedMom from 'src/hooks/useSelectedMom';
+import { useState, useEffect, memo } from 'react';
 import useSocketContext from 'src/hooks/useSocketContext';
 import { TMom } from 'src/types/mom';
 
@@ -7,10 +6,10 @@ import style from './style.module.scss';
 
 interface MomListProps {
   moms: TMom[];
+  setSelectedMom: React.Dispatch<React.SetStateAction<TMom | null>>;
 }
 
-function MomList({ moms }: MomListProps) {
-  const { selectedMom, setSelectedMom } = useSelectedMom();
+function MomList({ moms, setSelectedMom }: MomListProps) {
   const { momSocket: socket } = useSocketContext();
   const [momList, setMomList] = useState<TMom[]>(moms);
 
@@ -19,14 +18,15 @@ function MomList({ moms }: MomListProps) {
   };
 
   const onSelect = (targetId: string) => {
-    if (selectedMom && selectedMom._id === targetId) return;
     socket.emit('select-mom', targetId);
   };
 
   useEffect(() => {
     setMomList(moms);
 
-    socket.on('created-mom', (mom) => setMomList((prev) => [...prev, mom]));
+    socket.on('created-mom', (mom) => {
+      setMomList((prev) => [...prev, mom]);
+    });
 
     socket.on('selected-mom', (mom) => {
       setSelectedMom(mom);
@@ -53,4 +53,4 @@ function MomList({ moms }: MomListProps) {
   );
 }
 
-export default MomList;
+export default memo(MomList);

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -1,9 +1,9 @@
 import { WorkspaceInfo } from 'src/types/workspace';
 
 import ConfButton from './ConfButton';
+import Header from './Header';
 import MemberList from './MemberList';
 import MomList from './MomList';
-import SettingIcon from './SettingIcon';
 import style from './style.module.scss';
 
 interface SidebarProps {
@@ -13,10 +13,7 @@ interface SidebarProps {
 function Sidebar({ workspace }: SidebarProps) {
   return (
     <div className={style['sidebar-container']}>
-      <div className={style['header']}>
-        <h1>{workspace.name}</h1>
-        <SettingIcon />
-      </div>
+      <Header name={workspace.name} />
       <MemberList members={workspace.members} />
       <MomList moms={workspace.moms} />
       <ConfButton />

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+import useSelectedMom from 'src/hooks/useSelectedMom';
 import { WorkspaceInfo } from 'src/types/workspace';
 
 import ConfButton from './ConfButton';
@@ -5,17 +6,18 @@ import Header from './Header';
 import MemberList from './MemberList';
 import MomList from './MomList';
 import style from './style.module.scss';
-
 interface SidebarProps {
   workspace: WorkspaceInfo;
 }
 
 function Sidebar({ workspace }: SidebarProps) {
+  const { setSelectedMom } = useSelectedMom();
+
   return (
     <div className={style['sidebar-container']}>
       <Header name={workspace.name} />
       <MemberList members={workspace.members} />
-      <MomList moms={workspace.moms} />
+      <MomList moms={workspace.moms} setSelectedMom={setSelectedMom} />
       <ConfButton />
     </div>
   );

--- a/client/src/hooks/useSelectedMom.ts
+++ b/client/src/hooks/useSelectedMom.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { SelectedMomContext } from 'src/contexts/selected-mom';
 
-export default function useMom() {
+export default function useSelectedMom() {
   const context = useContext(SelectedMomContext);
 
   if (!context) throw new Error('아니요. 없어요.');


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->
- resolve: #182 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 회의록 선택 시 사이드바의 헤더나 MemberList가 리렌더링 되고 있었어요.
- 이 부분은 회의록 선택할 때 마다 렌더링 될 필요가 없어서 `memoization` 해줬습니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### ~~Q. MomList 는 클릭할때마다 계속 리렌더링이 돼요.~~ (해결 - 4번이랑 댓글 확인해주세요.)
devtool로 확인해보면 계속 하이라이팅이 되고 있어요. 아무리 memo하고 별짓 다 해봐도 계속 그래요.

눈물나요. 무지성 memo 하고 있었는데  이 부분 제대로 공부해볼래요...


####  💇 시도해본거

1. return값을 `useMemo`로 감싸기
```ts
console.log("mom-list");

return useMemo(() => {
  console.log('re-render!!');
  return (
    <div className={style['mom-list-container']}>
      <h2>회의록</h2>
      <ul className={style['mom-list']}>
        {momList.map(({ _id: id }) => (
          <li key={id} onClick={() => onSelect(id)}>
            {id}
          </li>
        ))}
      </ul>
      <button onClick={onCreateMom}>+ 회의록 추가</button>
    </div>
  );
}, [moms]);
```
- 결과
  - 이렇게 하면 워크스페이스가 바뀔 때만 `"re-render"`가 콘솔에 찍히고, 클릭할 땐 `'mom-list"`만 찍혀요.
  - 그래도 리렌더링은 계속 일어나고 있어요.
- 문제점
  - 신기하게도 현재 선택한 워크스페이스의 momList가 다음 워크스페이스를 클릭할 때 반영이돼요.
  ```text
  1. "왭" 워크스페이스 클릭 -> 이전 워크스페이스의 회의록
  2. "TEST" 워크스페이스 클릭 -> (1)에서 선택한 워크스페이스(왭)의 회의록
  3. "CRDT" 워크스페이스 클릭 -> (2)에서 선택한 워크스페이스(TEST)의 회의록
  ```
- 해결 방법
  - 제가 바보였어요. dependency array에 moms가 아니라 momList를 넣어야 했어요.
  - 그래도 여전히 리렌더링은 발생해요. 

https://user-images.githubusercontent.com/65100540/205036763-0f7b333a-2f5d-4b70-bba5-9cb90be6260c.mov



2. 컴포넌트를 memo로 감싸기
```ts
export default memo(MomList);
```
- 결과
  -  계속 리렌더링이 돼요.

3. (1) + (2)

- 결과
  - ~~(1)이랑 똑같이 순서가 뒤죽박죽이에요~~. 리렌더링이 계속 일어나요.

4. selectedMom 관련된것들 props로 내려줬어요.

```ts
// Sidebar.tsx
function Sidebar({ workspace }: SidebarProps) {
  const { setSelectedMom } = useSelectedMom();

  return (
    <div className={style['sidebar-container']}>
      <Header name={workspace.name} />
      <MemberList members={workspace.members} />
      <MomList moms={workspace.moms} setSelectedMom={setSelectedMom} />
      <ConfButton />
    </div>
  );
}

// MomList.tsx

export default memo(MomList);

```

- 결과
  - 원하는 결과를 얻었어요. 리렌더링이 되지 않아요.
  - 아직 Sidebar는 이전과 똑같은 상황에서도 리렌더링이 발생해요.
  - 그런데 그 안의 요소들이 다 memoization 되어 있어서 크게 영향은 없을 것 같아요.
  - 공부해보고 나중에 리팩토링 해볼게요!

https://user-images.githubusercontent.com/65100540/205062154-10affb05-10a5-465c-986d-a7eddfe88b47.mov



## 📷 스크린샷 (Optional)
- 일단 Sidebar의 `Header`, `MemberList`, `Confbar`는 리렌더링이 일어나지 않아요!

https://user-images.githubusercontent.com/65100540/205037576-88f7e76f-feb2-4a54-9811-ee096df769c7.mov

- 해결


https://user-images.githubusercontent.com/65100540/205062154-10affb05-10a5-465c-986d-a7eddfe88b47.mov


