### PR TITLE
Fix/#161-K: CRDT 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17490,7 +17490,7 @@
         "stylelint-config-prettier-scss": "^0.0.1",
         "stylelint-config-property-sort-order-smacss": "^9.0.0",
         "stylelint-config-recommended-scss": "^8.0.0",
-        "uuid": "*",
+        "uuid": "^9.0.0",
         "vite": "^3.2.3",
         "vite-tsconfig-paths": "^3.5.2"
       }

--- a/server/apis/mom/service.ts
+++ b/server/apis/mom/service.ts
@@ -1,7 +1,9 @@
 import workspaceModel from '@apis/workspace/model';
-import { info } from '@apis/workspace/service';
+import { Identifier, Node } from '@wabinar/crdt/node';
 import LinkedList from '@wabinar/crdt/linked-list';
 import momModel from './model';
+import { v4 as uuid } from 'uuid';
+import { createBlock } from './block/service';
 
 // TODO: 예외처리
 export const getMom = async (id: string) => {
@@ -10,7 +12,17 @@ export const getMom = async (id: string) => {
 };
 
 export const createMom = async (workspaceId: string) => {
-  const mom = await momModel.create({});
+  const blockId = uuid();
+  await createBlock(blockId);
+
+  const nodeId = new Identifier(1, -1);
+  const momNode = new Node(blockId, nodeId);
+  const defaultNodeMap = { [JSON.stringify(nodeId)]: momNode };
+
+  const mom = await momModel.create({
+    head: nodeId,
+    nodeMap: defaultNodeMap,
+  });
 
   await workspaceModel.updateOne(
     { id: workspaceId },

--- a/server/socket/mom.ts
+++ b/server/socket/mom.ts
@@ -73,13 +73,18 @@ async function momSocketServer(io: Server) {
 
         const blockIds = momCRDT.spread();
 
-        blockIds.forEach(async (id) => {
-          const { head, nodeMap } = await getBlock(id);
+        const blockMapInsertions = blockIds.map((id) => {
+          return new Promise<void>(async (resolve) => {
+            const { head, nodeMap } = await getBlock(id);
 
-          const blockCRDT = new CRDT(-1, { head, nodeMap } as LinkedList);
+            const blockCRDT = new CRDT(-1, { head, nodeMap } as LinkedList);
 
-          blockMap.set(id, blockCRDT);
+            blockMap.set(id, blockCRDT);
+            resolve();
+          });
         });
+
+        await Promise.all(blockMapInsertions);
       }
 
       // 선택된 회의록의 정보 전달


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

`block-initialization` 이벤트에 서버가 에러로 죽어버리는 버그 수정

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

.get(id)로 가져온 crdt가 undefined라서 서버가 진짜 개복치인 이슈가 있었는데요.
momSocketServer에서 crdt를 관리하기 위해 사용하는 blockMap이 초기화되지 않는게 원인이었어요.

- 기존에 프론트에서 테스트용으로 사용하던 `id='test' 더미 블럭`이 있었는데요.
  얘의 연산이 room 안에서 브로드캐스팅 되면서 momCRDT가 깨지는 상황인 것 같아서 전부 제거했어요. [fix: setBlocks 실행 시점 소켓서버 반영 이후로 조정](https://github.com/boostcampwm-2022/web27-Wabinar/commit/6ba256fb5b9bb3398b337372c4447a566032b593)
- 그리고 새로운 회의록이 생성될 때 빈 블럭을 하나 가지도록 했어요. [fix: createMom 서비스에서 회의록 당 기본 블럭이 하나씩 생성되도록 함](https://github.com/boostcampwm-2022/web27-Wabinar/commit/35796fa2378b6b1566fdc63337e370d1136b0453)

<br />

- 필요한 작업이긴 했는데 사실 얘네들이 진짜 원인은 아니었어요.
- [fix: 소켓서버 blockMap에 엔트리가 없는 버그 수정](https://github.com/boostcampwm-2022/web27-Wabinar/commit/661baf9843436117f12909e8da0968e1fd4c1465) 에서 Promise.all로 db 연산과 blockMap.set 완료를 보장하도록 했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)