### PR TITLE
Fix/#186-C: 본인 목소리 안 들리도록 개선

### DIFF
--- a/client/src/components/ConfMediaBar/ConfMedia/index.tsx
+++ b/client/src/components/ConfMediaBar/ConfMedia/index.tsx
@@ -4,9 +4,10 @@ import style from './style.module.scss';
 
 interface MediaProps {
   stream: MediaStream;
+  muted: boolean;
 }
 
-function ConfMedia({ stream }: MediaProps) {
+function ConfMedia({ stream, muted }: MediaProps) {
   const ref = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -14,7 +15,7 @@ function ConfMedia({ stream }: MediaProps) {
     ref.current.srcObject = stream;
   }, [stream]);
 
-  return <video className={style.video} ref={ref} autoPlay />;
+  return <video className={style.video} ref={ref} muted={muted} autoPlay />;
 }
 
 export default memo(ConfMedia);

--- a/client/src/components/ConfMediaBar/index.tsx
+++ b/client/src/components/ConfMediaBar/index.tsx
@@ -20,7 +20,7 @@ function ConfMediaBar() {
       <ul>
         {Array.from(streams).map(([id, stream]) => (
           <li key={id}>
-            <ConfMedia key={id} stream={stream} />
+            <ConfMedia key={id} stream={stream} muted={id === 'me' ? true : false} />
             <StreamButton
               isMicOn={false}
               isCamOn={true} // TODO: 임시로 지정


### PR DESCRIPTION
## 🤠 개요

- resolves #186

## 💫 설명

본인에 대한 `video` 엘리먼트는 `mute` 하도록 했어요.

## 🌜 고민거리 (Optional)

본인에 대한 `video` 엘리먼트인지 검사하는 로직이 마음에 안듭니다.

`socketId === me` 인 조건으로 본인인지 알아내고 있는데요.
`socketId`는 이런 식으로 쓰는 값이 아니니까 다른 변수를 만들어야겠다고 생각은 했는데...
근데 여기서 뭔가 더 하면 issue 목적에 안맞는 것 같아서 일단 뒀어요.

좀더 나은 방법이 떠오르면 그때 refactoring 이슈 달고 해볼게요. (아니면 다른 분들이 하셔도 괜찮아요.)

## 📷 스크린샷 (Optional)