### PR TITLE
fix/#192-S : 워크스페이스 선택 시 첫번째 회의록이 렌더링되지 않는 버그 해결

### DIFF
--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -21,7 +21,9 @@ function Workspace({ workspaceId }: WorkspaceProps) {
   const loadWorkspaceInfo = async () => {
     if (workspaceId) {
       const workspaceInfo = await getWorkspaceInfo({ id: workspaceId });
+
       setWorkspace(workspaceInfo);
+      setSelectedMom(workspaceInfo.moms[0]);
     }
   };
 


### PR DESCRIPTION
## 🤠 개요

- resolve #192 
- 첫번째 회의록으로 선택된 회의록 변경

## 💫 설명

- 워크스페이스 정보를 불러오고 selectedMom을 변경해주지 않고 있더라고요

## 🌜 고민거리 (Optional)

## 📷 스크린샷 (Optional)