### PR TITLE
Chore/#223-C: CI에서 백엔드 코드가 실행되는지 테스트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,28 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    
     - name: For client directory
       run: |
         cd client
         npm run build --if-present
         npm test --if-present
+        
+    - name: Install coreutils for macOS
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+        brew install coreutils
+        alias timeout=gtimeout
+        
     - name: For server directory
+      shell: bash
+      env:
+        BACKEND_LOGIN_KEY: ${{ secrets.DOTENV_VAULT_BACKEND_CI_LOGIN_KEY }}
       run: |
         cd server
         npm run build --if-present
         npm test --if-present
+        npx dotenv-vault login "$BACKEND_LOGIN_KEY" > /dev/null
+        npx dotenv-vault pull ci .env
+        timeout --verbose 10 npx ts-node index.ts || { if [ $? -eq 124 ]; then (exit 0); else (exit $?); fi }

--- a/server/tsconfig.path.json
+++ b/server/tsconfig.path.json
@@ -10,8 +10,7 @@
       "@middlewares/*": ["middlewares/*"],
       "@utils/*": ["utils/*"],
       "@params/*": ["../types/params/*"],
-      "@socket": ["socket"],
-      "@wabinar/crdt": ["../@wabinar-crdt"]
+      "@socket": ["socket"]
     }
   }
 }


### PR DESCRIPTION
## 🤠 개요

- resolves #223

빌드 테스트와 별도로 테스트. 10초간 문제 없으면 통과

## 💫 설명

[어제 실수로 들어간 파일](https://github.com/boostcampwm-2022/web27-Wabinar/pull/214/files#diff-b69e18a5b80fe64907656776ddfc19ed8a9f14f0f0b7b9e6f2deb6d5e5cc43a1) 때문에 로컬에서 `npm run dev`가 실행이 안되는 문제가 있었습니다.

이를 해결하기 위해 CI 단계에서 실행을 해보고 10초간 문제 없으면 통과하도록 만들었습니다.

`timeout` 커맨드
- 10초가 지나면 `timeout`은 exit code로 `124`를 반환합니다. 그 전에 문제가 있어서 종료되면 그 exit code를 반환합니다.
- 따라서 `124`와 `0` (정상종료)가 아닌 다른 exit 코드가 반환되면 CI는 실패했다고 알려줍니다.
- macOS에는 디폴트로 설치되어 있지 않아서 `coreutils`를 설치합니다.

`dotenv-vault`
- `ci` 환경을 위한 환경변수를 설정했습니다. 지금은 `dev`랑 똑같습니다. CI는 이 환경변수를 사용합니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)

fork repo에서 정상 작동을 확인했습니다.

### 백엔드 코드가 실행이 안될 때

![screenshot1](https://user-images.githubusercontent.com/89635107/205806128-0458585f-ec55-4d45-a582-c617e6387563.png)

`backend/tsconfig.path.json`의 `path`에
```json
      "@wabinar/crdt": ["../@wabinar-crdt"]
```
이 포함되어 있으면 CI는 실패를 알려줍니다.

### 실행이 될 때

![screenshot2](https://user-images.githubusercontent.com/89635107/205806058-1c14385d-65d2-4143-9735-062e3cfee8c8.png)

위에서 언급한 `"@wabinar/crdt": ["../@wabinar-crdt"]`가 없는 경우 CI는 통과합니다.
