### PR TITLE
Fix/#226-K: 블럭 내부 좌우 방향키 커서 핸들러 개선

### DIFF
--- a/client/src/components/Mom/Block/index.tsx
+++ b/client/src/components/Mom/Block/index.tsx
@@ -159,6 +159,13 @@ function Block({ id, onKeyDown, index }: BlockProps) {
     e.preventDefault();
   };
 
+  const onKeyDownComposite: React.KeyboardEventHandler<HTMLParagraphElement> = (
+    e,
+  ) => {
+    offsetHandlers.onKeyDown(e);
+    onKeyDown(e);
+  };
+
   return (
     <p
       ref={blockRef}
@@ -167,7 +174,7 @@ function Block({ id, onKeyDown, index }: BlockProps) {
       onInput={onInput}
       onCompositionEnd={onCompositionEnd}
       {...offsetHandlers}
-      onKeyDown={onKeyDown}
+      onKeyDown={onKeyDownComposite}
       onPaste={onPaste}
       suppressContentEditableWarning={true}
     >

--- a/client/src/components/Mom/Block/index.tsx
+++ b/client/src/components/Mom/Block/index.tsx
@@ -28,9 +28,10 @@ function Block({ id, onKeyDown, index }: BlockProps) {
     remoteDeleteCRDT,
   } = useCRDT();
 
-  const { offsetRef, setOffset, clearOffset, offsetHandlers } = useOffset();
-
   const blockRef = useRef<HTMLParagraphElement>(null);
+
+  const { offsetRef, setOffset, clearOffset, offsetHandlers } =
+    useOffset(blockRef);
 
   // 로컬에서 일어나는 작성 - 삽입과 삭제 연산
   const onInput: React.FormEventHandler = (e) => {

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -3,13 +3,13 @@ import { useRef } from 'react';
 export function useOffset() {
   const offsetRef = useRef<number | null>(null);
 
-  const setOffset = () => {
+  const setOffset = (offset = 0) => {
     const selection = window.getSelection();
 
     if (selection?.rangeCount) {
       const range = selection.getRangeAt(0);
 
-      offsetRef.current = range.startOffset;
+      offsetRef.current = range.startOffset + offset;
     }
   };
 
@@ -17,10 +17,27 @@ export function useOffset() {
     offsetRef.current = null;
   };
 
-  const onKeyUp: React.KeyboardEventHandler = (e) => {
-    const arrowKeys = ['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'];
+  // keydown 이벤트는 키 입력의 내용 반영 이전에 발생
+  const onKeyDown: React.KeyboardEventHandler = (e) => {
+    const ARROW_LEFT = 'ArrowLeft';
+    const ARROW_RIGHT = 'ArrowRight';
 
-    if (arrowKeys.includes(e.nativeEvent.key)) {
+    switch (e.nativeEvent.key) {
+      case ARROW_LEFT:
+        setOffset(-1);
+        return;
+      case ARROW_RIGHT:
+        setOffset(1);
+        return;
+    }
+  };
+
+  // 위 아래 방향키 이동은 핸들링하지 않음
+  const onKeyUp: React.KeyboardEventHandler = (e) => {
+    const ARROW_DOWN = 'ArrowDown';
+    const ARROW_UP = 'ArrowUp';
+
+    if ([ARROW_DOWN, ARROW_UP].includes(e.nativeEvent.key)) {
       setOffset();
     }
   };
@@ -29,7 +46,8 @@ export function useOffset() {
     onFocus: setOffset,
     onClick: setOffset,
     onBlur: clearOffset,
-    onKeyUp: onKeyUp,
+    onKeyDown,
+    onKeyUp,
   };
 
   return {

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -1,17 +1,26 @@
 import { useRef } from 'react';
 
-export function useOffset() {
+export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   const offsetRef = useRef<number | null>(null);
 
   const setOffset = (offset = 0) => {
+    if (!blockRef.current) return;
+
     const selection = window.getSelection();
 
     if (selection?.rangeCount) {
       const range = selection.getRangeAt(0);
 
+      const preCaretRange = range.cloneRange();
+      preCaretRange.selectNodeContents(
+        blockRef.current as HTMLParagraphElement,
+      );
+      preCaretRange.setEnd(range.endContainer, range.endOffset);
+      const maxOffset = preCaretRange.toString().length;
+
       const nextOffset = range.startOffset + offset;
 
-      offsetRef.current = Math.max(0, nextOffset);
+      offsetRef.current = Math.min(maxOffset, Math.max(0, nextOffset));
     }
   };
 

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -9,7 +9,9 @@ export function useOffset() {
     if (selection?.rangeCount) {
       const range = selection.getRangeAt(0);
 
-      offsetRef.current = range.startOffset + offset;
+      const nextOffset = range.startOffset + offset;
+
+      offsetRef.current = Math.max(0, nextOffset);
     }
   };
 

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 
 export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   const offsetRef = useRef<number | null>(null);
@@ -54,8 +54,10 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   };
 
   const offsetHandlers = {
-    onFocus: setOffset,
-    onClick: setOffset,
+    onFocus:
+      setOffset as unknown as React.FocusEventHandler<HTMLParagraphElement>,
+    onClick:
+      setOffset as unknown as React.MouseEventHandler<HTMLParagraphElement>,
     onBlur: clearOffset,
     onKeyDown,
     onKeyUp,


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Resolves #226 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- onKeyUp에 달려있던 커서 위치 핸들러 로직의 일부를 onKeyDown으로 이동해요.
- -1 +1 해준 값이 유효한 offset인지 확인하는 로직이 필요해져서 넣어줬어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)