### PR TITLE
Chore/Temp-C: 배포 스크립트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore secret keys
+deploy-scripts/vault-secrets
+
 # ignore settings for yarn berry zero install
 .yarn/*
 !.yarn/cache

--- a/deploy-scripts/build-backend.sh
+++ b/deploy-scripts/build-backend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source ./config.sh
+
+cd ${BACKEND_DIR}
+npm run build

--- a/deploy-scripts/build-frontend.sh
+++ b/deploy-scripts/build-frontend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source ./config.sh
+
+cd ${FRONTEND_DIR}
+npm run build

--- a/deploy-scripts/config.sh
+++ b/deploy-scripts/config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+PROJECT_BASE_DIR=/home/wabuser/wabinar
+FRONTEND_DIR=${PROJECT_BASE_DIR}/client
+BACKEND_DIR=${PROJECT_BASE_DIR}/server
+VAULT_KEY_FILE=${PROJECT_BASE_DIR}/deploy-scripts/vault-secrets/keys

--- a/deploy-scripts/try-dotenv-vault-login.sh
+++ b/deploy-scripts/try-dotenv-vault-login.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+source ./config.sh
+
+source ${VAULT_KEY_FILE}
+
+cd ${FRONTEND_DIR}
+if [ ! -f ./.env.me ]; then
+        npx dotenv-vault login ${VAULT_FRONTEND_KEY} > /dev/null
+fi
+
+cd ${BACKEND_DIR}
+if [ ! -f ./.env.me ]; then
+        npx dotenv-vault login ${VAULT_BACKEND_KEY} > /dev/null
+fi
+
+echo "dotenv-vault login done"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd deploy-scripts
+(source try-dotenv-vault-login.sh)
+(source build-backend.sh)
+(source build-frontend.sh)


### PR DESCRIPTION
## 🤠 개요

배포 서버에 있었던 배포 스크립트를 프로젝트 디렉토리에 가져왔습니다. (세영님의 무수한 요청으로..)

가져오면서 읽기 쉽게 리팩토링 했어요.

배포를 위한 시작 스크립트는 `deploy.sh`이고, 실제 코드는 기능별로 `deploy-scripts` 폴더에 나눠져 있습니다.

`deploy-scripts/vault-secrets`는 dotenv-vault의 로그인 비밀키가 있는 폴더입니다. (`.gitignore`로 무시)

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)