### PR TITLE
Feat/#229-S : axios 에러 interceptor 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,6 @@
   "name": "client",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -17,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-loader-spinner": "^5.3.4",
     "react-router-dom": "^6.4.3",
+    "react-toastify": "^9.1.1",
     "socket.io-client": "^4.5.4",
     "uuid": "^9.0.0"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,47 +1,28 @@
-import { useEffect, useState } from 'react';
-import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { getAuth } from 'src/apis/auth';
+import { Suspense, useState } from 'react';
+import { Route, Routes } from 'react-router-dom';
 import UserContext from 'src/contexts/user';
-import { LoadingPage, LoginPage, OAuthPage, WorkspacePage } from 'src/pages';
+import { LoginPage, OAuthPage, WorkspacePage } from 'src/pages';
 import { User } from 'src/types/user';
+
+import Loader from './components/common/Loader';
+import NotFoundPage from './pages/404';
 
 import 'styles/reset.scss';
 
 function App() {
-  const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [user, setUser] = useState<User | null>(null);
 
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  const autoLogin = async () => {
-    const { user } = await getAuth();
-
-    setIsLoaded(true);
-
-    if (!user) {
-      if (location.pathname.match('/workspace')) navigate('/');
-      return;
-    }
-
-    setUser(user);
-    navigate('/workspace');
-  };
-
-  useEffect(() => {
-    autoLogin();
-  }, []);
-
-  return isLoaded ? (
-    <UserContext.Provider value={{ user, setUser }}>
-      <Routes>
-        <Route path="/" element={<LoginPage />} />
-        <Route path="/oauth" element={<OAuthPage />} />
-        <Route path="/workspace/*" element={<WorkspacePage />} />
-      </Routes>
-    </UserContext.Provider>
-  ) : (
-    <LoadingPage />
+  return (
+    <Suspense fallback={<Loader size={100} />}>
+      <UserContext.Provider value={{ user, setUser }}>
+        <Routes>
+          <Route path="/" element={<LoginPage />} />
+          <Route path="/oauth" element={<OAuthPage />} />
+          <Route path="/workspace/*" element={<WorkspacePage />} />
+          <Route path="/404" element={<NotFoundPage />} />
+        </Routes>
+      </UserContext.Provider>
+    </Suspense>
   );
 }
 

--- a/client/src/apis/http.ts
+++ b/client/src/apis/http.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import env from 'config';
+import { toast } from 'react-toastify';
 
 const SERVER_PATH = env.SERVER_PATH;
 
@@ -7,3 +8,29 @@ export const http = axios.create({
   baseURL: SERVER_PATH,
   withCredentials: true,
 });
+
+http.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response && err.response.status) {
+      switch (err.response.status) {
+        case 401:
+          console.debug(401);
+          break;
+        case 403:
+          console.debug(403);
+          break;
+        case 404:
+          console.debug(404);
+          window.location.href = '/404';
+          break;
+        case 500:
+          console.debug(500);
+          toast('500 Network Error .. ^^', { type: 'error' });
+          break;
+        default:
+          return;
+      }
+    }
+  },
+);

--- a/client/src/apis/http.ts
+++ b/client/src/apis/http.ts
@@ -15,17 +15,17 @@ http.interceptors.response.use(
     if (err.response && err.response.status) {
       switch (err.response.status) {
         case 401:
-          console.debug(401);
+          if (window.location.pathname !== '/') window.location.href = '/';
+          toast('다시 로그인해주세요 .. ^^', { type: 'warning' });
           break;
         case 403:
-          console.debug(403);
+          if (window.location.pathname !== '/') window.location.href = '/';
+          toast('다시 로그인해주세요 .. ^^', { type: 'warning' });
           break;
         case 404:
-          console.debug(404);
           window.location.href = '/404';
           break;
         case 500:
-          console.debug(500);
           toast('500 Network Error .. ^^', { type: 'error' });
           break;
         default:

--- a/client/src/components/common/Toaster/index.tsx
+++ b/client/src/components/common/Toaster/index.tsx
@@ -1,0 +1,13 @@
+import { ToastContainer } from 'react-toastify';
+
+function Toaster() {
+  return (
+    <ToastContainer
+      autoClose={2500}
+      position="top-right"
+      pauseOnHover={false}
+    />
+  );
+}
+
+export default Toaster;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
+import 'react-toastify/dist/ReactToastify.css';
 import App from './App';
+import Toaster from './components/common/Toaster';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <BrowserRouter>
     <App />
+    <Toaster />
   </BrowserRouter>,
 );

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+import WabIcon from 'src/components/common/Icon/Wab';
+
+function NotFoundPage() {
+  useEffect(() => {
+    toast('404 Not Found .. ^^', {
+      type: 'error',
+    });
+  }, []);
+
+  return (
+    <div>
+      <h1>404 Page</h1>
+      <WabIcon />
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -3,11 +3,35 @@ import BubblesIcon from 'common/Icon/Bubbles';
 import GithubIcon from 'common/Icon/Github';
 import LogoIcon from 'common/Icon/Logo';
 import env from 'config';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { getAuth } from 'src/apis/auth';
+import { useUserContext } from 'src/hooks/useUserContext';
 
 import style from './style.module.scss';
 
 function LoginPage() {
   const GITHUB_AUTH_URL = `https://github.com/login/oauth/authorize?client_id=${env.GITHUB_CLIENT_ID}`;
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { setUser } = useUserContext();
+
+  const autoLogin = async () => {
+    const { user } = await getAuth();
+
+    if (!user) {
+      if (location.pathname.match('/workspace')) navigate('/');
+      return;
+    }
+
+    setUser(user);
+    navigate('/workspace');
+  };
+
+  useEffect(() => {
+    autoLogin();
+  }, []);
 
   return (
     <div className={style.container}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-dom": "^18.2.0",
         "react-loader-spinner": "^5.3.4",
         "react-router-dom": "^6.4.3",
+        "react-toastify": "^9.1.1",
         "socket.io-client": "^4.5.4",
         "uuid": "^9.0.0"
       },
@@ -1164,21 +1165,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
-      "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
+      "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.2",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-compilation-targets": "^7.20.0",
         "@babel/helper-module-transforms": "^7.20.2",
-        "@babel/helpers": "^7.20.1",
-        "@babel/parser": "^7.20.2",
+        "@babel/helpers": "^7.20.5",
+        "@babel/parser": "^7.20.5",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1203,11 +1204,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
+      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
       "dependencies": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -1385,14 +1386,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
-      "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
+      "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.0"
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1476,9 +1477,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1728,12 +1729,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dev": true,
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1753,18 +1754,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
+      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1773,9 +1774,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
+      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -3268,9 +3269,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.3.tgz",
-      "integrity": "sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==",
+      "version": "29.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.4.tgz",
+      "integrity": "sha512-PipFB04k2qTRPePduVLTRiPzQfvMeLwUN3Z21hsAKaB/W9IIzgB2pizCL466ftJlcyZqnHoC9ZHpxLGl3fS86A==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -4703,6 +4704,14 @@
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -11408,6 +11417,18 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -11583,9 +11604,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
@@ -14859,21 +14880,21 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
-      "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
+      "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.2",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-compilation-targets": "^7.20.0",
         "@babel/helper-module-transforms": "^7.20.2",
-        "@babel/helpers": "^7.20.1",
-        "@babel/parser": "^7.20.2",
+        "@babel/helpers": "^7.20.5",
+        "@babel/parser": "^7.20.5",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -14890,11 +14911,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
+      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
       "requires": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -15025,14 +15046,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
-      "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
+      "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.0"
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       }
     },
     "@babel/highlight": {
@@ -15097,9 +15118,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -15268,12 +15289,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -15287,26 +15308,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
+      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
+      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -15344,7 +15365,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emotion/is-prop-valid": {
       "version": "1.2.0",
@@ -16241,7 +16263,8 @@
     "@react-icons/all-files": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
-      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ=="
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "requires": {}
     },
     "@remix-run/router": {
       "version": "1.0.3",
@@ -16470,9 +16493,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.3.tgz",
-      "integrity": "sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==",
+      "version": "29.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.4.tgz",
+      "integrity": "sha512-PipFB04k2qTRPePduVLTRiPzQfvMeLwUN3Z21hsAKaB/W9IIzgB2pizCL466ftJlcyZqnHoC9ZHpxLGl3fS86A==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",
@@ -16806,7 +16829,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -17484,6 +17508,7 @@
         "react-dom": "^18.2.0",
         "react-loader-spinner": "^5.3.4",
         "react-router-dom": "^6.4.3",
+        "react-toastify": "^9.1.1",
         "sass": "^1.56.1",
         "socket.io-client": "^4.5.4",
         "stylelint": "^14.15.0",
@@ -17550,6 +17575,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "co": {
       "version": "4.6.0",
@@ -18462,7 +18492,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -20427,7 +20458,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.2.0",
@@ -22143,13 +22175,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-scss": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
       "integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -22358,6 +22392,14 @@
         "react-router": "6.4.3"
       }
     },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -22495,9 +22537,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -23276,7 +23318,8 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
       "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-prettier-scss": {
       "version": "0.0.1",
@@ -23301,7 +23344,8 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
       "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylelint-config-recommended-scss": {
       "version": "8.0.0",
@@ -23328,7 +23372,8 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
           "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -24069,7 +24114,8 @@
     "ws": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "requires": {}
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",


### PR DESCRIPTION
## 🤠 개요

- resolve #229 #234 
- axios 에러 interceptor 구현 및 토스트 메세지 구현


## 💫 설명

- 기존에는 에러가 발생하면 `throw new Error()`로 에러만 뱉어주고 있었어요
- axios의 interceptor 기능을 이용해서 401, 403, 404, 500 에러에 대응해주었어요
- `공통`: 토스트 메세지 띄워주기
  - 401, 403: 로그인 페이지로 이동
  - 404: 404 페이지로 이동 (UI는 임의로 만들었어요)
  - 500: 토스트 메세지 띄워주기

## 🌜 고민거리 (Optional)

## 📷 스크린샷 (Optional)

- 404 일 경우

https://user-images.githubusercontent.com/63364990/205889338-72d503ab-4651-45fa-880b-9625abf17bf0.mov

- 500 일 경우

https://user-images.githubusercontent.com/63364990/205889053-73724c60-e19a-47d7-a583-0dce85011e25.mov

- 401, 403 일 경우

https://user-images.githubusercontent.com/63364990/205891346-0d7f707f-e34f-4388-ae6d-c0832abef1fe.mov