### PR TITLE
Fix/#220-C: 워크스페이스 변경시에도 화상회의가 지속되는 버그 해결

### DIFF
--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -44,6 +44,7 @@ function Workspace() {
     });
     
     loadWorkspaceInfo();
+    setIsStart(false);
 
     return () => {
       setMomSocket(prev => {


### PR DESCRIPTION
## 🤠 개요

- resolves #220

## 💫 설명

워크스페이스 변경 시 연결된 화상회의를 닫도록 수정했습니다.

## 🌜 고민거리 (Optional)

## 📷 스크린샷 (Optional)