### PR TITLE
Chore/#265-C: 백엔드 빌드 디렉토리에 환경변수 파일 복사

### DIFF
--- a/deploy-scripts/build-frontend-and-backend.sh
+++ b/deploy-scripts/build-frontend-and-backend.sh
@@ -6,3 +6,6 @@ git pull origin main
 
 npm ci
 npm run deploy # main 브랜치 빌드
+
+cd ${BACKEND_DIR}
+cp .env ./dist


### PR DESCRIPTION
## 🤠 개요

- resolves #265

## 💫 설명

백엔드 빌드 디렉토리에 환경변수 파일 `.env`가 없는 이슈가 있어서, 복사해 넣는 스크립트를 추가합니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)