### PR TITLE
Feat/#290-B: MeetingMedia에 username 추가

### DIFF
--- a/client/src/components/MeetingMediaBar/MeetingMedia/index.tsx
+++ b/client/src/components/MeetingMediaBar/MeetingMedia/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useRef } from 'react';
+import { useUserContext } from 'src/hooks/useUserContext';
 
 import style from './style.module.scss';
 
@@ -9,13 +10,23 @@ interface MediaProps {
 
 function MeetingMedia({ stream, muted }: MediaProps) {
   const ref = useRef<HTMLVideoElement>(null);
+  const { user } = useUserContext();
+
+  const defaultUsername = '익명';
 
   useEffect(() => {
     if (!ref.current) return;
     ref.current.srcObject = stream;
   }, [stream]);
 
-  return <video className={style.video} ref={ref} muted={muted} autoPlay />;
+  return (
+    <>
+      <video className={style.video} ref={ref} muted={muted} autoPlay />
+      <span className={style.username}>
+        {user ? user.name : defaultUsername}
+      </span>
+    </>
+  );
 }
 
 export default memo(MeetingMedia);

--- a/client/src/components/MeetingMediaBar/MeetingMedia/style.module.scss
+++ b/client/src/components/MeetingMediaBar/MeetingMedia/style.module.scss
@@ -1,5 +1,23 @@
+@import 'styles/color.module';
+
 .video {
   width: 240px;
   height: 180px;
   border-radius: 20px;
+}
+
+.username {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+
+  padding: 2px 6px;
+
+  border-radius: 5px;
+
+  background-color: rgba($color: $gray-100, $alpha: 0.8);
+  color: $white;
+
+  font-size: small;
+  font-weight: 500;
 }


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #290 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 카메라를 끄면 검은화면만 보여서 누가 누군지 확인하기가 어려워요.
- 그래서 카메라에 username을 추가했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

### Q. 위치 어디가 더 괜찮나요?

- 위

https://user-images.githubusercontent.com/65100540/206409391-9b7c604c-a5c5-418d-a2f6-dffe95874db4.mov

- 아래

https://user-images.githubusercontent.com/65100540/206409364-df61125a-0ebd-4ac1-abe2-922135ccfffb.mov

## 📷 스크린샷 (Optional)



