### PR TITLE
Chore/#305-K: 클라이언트 번들 코드 스플리팅

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,11 +1,11 @@
 import { resolve } from 'path';
 
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, splitVendorChunkPlugin } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), splitVendorChunkPlugin()],
   resolve: {
     alias: [
       { find: 'src', replacement: resolve(__dirname, './src') },


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Closes #305 
- vite의 splitVendorChunkPlugin, manualChunks 옵션을 설정해 클라이언트 번들 사이즈를 줄여봐요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- vite에서 번들을 쪼갤 때 사용하는 [splitVendorChunkPlugin](https://vitejs-kr.github.io/guide/build.html#chunking-strategy)을 달았어요.

- <s>빌드 결과를 gzip 압축하기 위해서 [vite-plugin-compression](https://github.com/vbenjs/vite-plugin-compression/tree/main#readme)을 사용했어요.
  추가하기 전에도 빌드 뒤에 gzip 사이즈를 알려주길래 이미 압축 해주는거 아닌가 싶었는데 dist 폴더 확인해보면 압축하는건 아니더라고요.</s>

- gzip 압축은 Nginx 설정만으로 가능하다고 해요. 코드 스플릿만 하고 gzip은 서버 설정 파일에서 적용할게요.
  https://docs.nginx.com/nginx/admin-guide/web-server/compression/

## 🌜 고민거리

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

`vite.config.ts`에 [rollupOptions.output.manualChunks](https://rollupjs.org/guide/en/#outputmanualchunks) 옵션을 설정해서 모듈을 별도의 청크로 분리할 수 있어요.
이건 어떤 파일에 적용하면 좋을지 고민해보고 사용해야 할 것 같아요.

```ts
// 예시

  build: {
    rollupOptions: {
      output: {
        manualChunks: {
          '@wabinar/crdt': ['@wabinar/crdt'],
        },
      },
    },
  },
```

## 📷 스크린샷

#### splitVendorChunkPlugin 전
![image](https://user-images.githubusercontent.com/63814960/206834036-445b1bc0-4597-4db2-87d0-3072445129a0.png)

#### splitVendorChunkPlugin 후
<img width="514" alt="image" src="https://user-images.githubusercontent.com/63814960/206834004-48aa21df-2352-41ff-86c1-f9840c84cf25.png">

<h4><s>viteCompression 전</s></h4>

![스크린샷 2022-12-12 오전 11 19 11](https://user-images.githubusercontent.com/63814960/206947306-17f5e5d5-db94-4792-b19b-e33bd770e77d.png)

<h4><s>viteCompression 후</s></h4>

![스크린샷 2022-12-12 오전 11 19 30](https://user-images.githubusercontent.com/63814960/206947298-769a042d-a6b1-44aa-b614-d0c2374a0004.png)
![image](https://user-images.githubusercontent.com/63814960/206947570-9e1aa9fa-5a07-4bd6-bf0f-5749a683b56e.png)
