### PR TITLE
Feat/#300-K: 투표 블럭을 생성한 사람만 등록 가능하도록 수정

### DIFF
--- a/@wabinar/constants/socket-message.ts
+++ b/@wabinar/constants/socket-message.ts
@@ -29,7 +29,7 @@ export const BLOCK_EVENT = {
   INSERT_TEXT: 'insert-text',
   DELETE_TEXT: 'delete-text',
   UPDATE_TEXT: 'update-text',
-  CREATE_VOTE: 'create-vote',
+  REGISTER_VOTE: 'register-vote',
   UPDATE_VOTE: 'update-vote',
   END_VOTE: 'end-vote',
   FETCH_QUESTIONS: 'fetch-questions',

--- a/@wabinar/constants/socket-message.ts
+++ b/@wabinar/constants/socket-message.ts
@@ -23,9 +23,9 @@ export const MOM_EVENT = {
 };
 
 export const BLOCK_EVENT = {
-  INIT: 'init-block',
   LOAD_TYPE: 'load-type',
   UPDATE_TYPE: 'update-type',
+  INIT_TEXT: 'init-text',
   INSERT_TEXT: 'insert-text',
   DELETE_TEXT: 'delete-text',
   UPDATE_TEXT: 'update-text',

--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -112,15 +112,15 @@ function TextBlock({
   useEffect(() => {
     registerRef(blockRef);
 
-    socket.emit(BLOCK_EVENT.INIT, id);
+    socket.emit(BLOCK_EVENT.INIT_TEXT, id);
 
-    ee.on(`${BLOCK_EVENT.INIT}-${id}`, onInitialize);
+    ee.on(`${BLOCK_EVENT.INIT_TEXT}-${id}`, onInitialize);
     ee.on(`${BLOCK_EVENT.UPDATE_TEXT}-${id}`, onInitialize);
     ee.on(`${BLOCK_EVENT.INSERT_TEXT}-${id}`, onInsert);
     ee.on(`${BLOCK_EVENT.DELETE_TEXT}-${id}`, onDelete);
 
     return () => {
-      ee.off(`${BLOCK_EVENT.INIT}-${id}`, onInitialize);
+      ee.off(`${BLOCK_EVENT.INIT_TEXT}-${id}`, onInitialize);
       ee.off(`${BLOCK_EVENT.UPDATE_TEXT}-${id}`, onInitialize);
       ee.off(`${BLOCK_EVENT.INSERT_TEXT}-${id}`, onInsert);
       ee.off(`${BLOCK_EVENT.DELETE_TEXT}-${id}`, onDelete);

--- a/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
+++ b/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
@@ -144,65 +144,68 @@ function VoteBlockTemplate({
 
   return (
     <div className={style['vote-container']}>
-      <h3 className={style.title}>
-        {isCreateMode ? '투표 등록중 ^^' : '투표'}
-      </h3>
+      <h3 className={style.title}>{'투표'}</h3>
       {(isRegisteredMode || isEndMode) && (
         <span className={style['participant-cnt']}>
           {participantCount}명 참여
         </span>
       )}
-      {isCreateMode ? (
-        <></>
-      ) : (
+      {
         <ul>
-          {options.map(({ id, text, count }, index) => (
-            <li
-              className={cx('option-item', {
-                'selected-item':
-                  (isRegisteredMode || isEndMode) && id === selectedOptionId,
-              })}
-              key={id}
-              onClick={() => onSelect(id)}
-            >
-              {isEndMode && (
-                <div
-                  className={style['vote-result-bar']}
-                  style={{
-                    width: `${getPercent(count)}%`,
-                    backgroundColor: color.highlight100,
-                  }}
-                ></div>
-              )}
-
-              <div className={style['box-fill']}>{index + 1}</div>
-              <input
-                type="text"
-                className={cx('option-input', {
-                  selected: isRegisteredMode,
-                })}
-                placeholder="항목을 입력해주세요"
-                onChange={onChange}
-                data-id={id}
-                readOnly={isRegisteredMode || isEndMode}
-                defaultValue={text}
-              />
-              {isRegisteringMode && (
-                <Button
-                  icon={<BiX size="20" color="white" />}
-                  ariaLabel="항목 삭제"
-                  onClick={() => onDelete(id)}
-                />
-              )}
-              {isEndMode && (
-                <div className={style['vote-result-text']}>
-                  {getVoteResultText(count)}
-                </div>
-              )}
+          {isCreateMode ? (
+            <li className={style['option-item']}>
+              <div className={style['box-fill']}>{'^^'}</div>
+              <div>등록될 때까지 기다려주세요</div>
             </li>
-          ))}
+          ) : (
+            options.map(({ id, text, count }, index) => (
+              <li
+                className={cx('option-item', {
+                  'selected-item':
+                    (isRegisteredMode || isEndMode) && id === selectedOptionId,
+                })}
+                key={id}
+                onClick={() => onSelect(id)}
+              >
+                {isEndMode && (
+                  <div
+                    className={style['vote-result-bar']}
+                    style={{
+                      width: `${getPercent(count)}%`,
+                      backgroundColor: color.highlight100,
+                    }}
+                  ></div>
+                )}
+
+                <div className={style['box-fill']}>{index + 1}</div>
+                <input
+                  type="text"
+                  className={cx('option-input', {
+                    selected: isRegisteredMode,
+                  })}
+                  placeholder="항목을 입력해주세요"
+                  onChange={onChange}
+                  data-id={id}
+                  readOnly={isRegisteredMode || isEndMode}
+                  defaultValue={text}
+                />
+                {isRegisteringMode && (
+                  <Button
+                    icon={<BiX size="20" color="white" />}
+                    ariaLabel="항목 삭제"
+                    onClick={() => onDelete(id)}
+                  />
+                )}
+                {isEndMode && (
+                  <div className={style['vote-result-text']}>
+                    {getVoteResultText(count)}
+                  </div>
+                )}
+              </li>
+            ))
+          )}
         </ul>
-      )}
+      }
       <div className={style['vote-buttons']}>
         {isRegisteringMode && (
           <>

--- a/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
+++ b/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
@@ -67,7 +67,7 @@ function VoteBlockTemplate({
     setOptions(validOptions);
     setVoteMode(VoteMode.REGISTERED);
 
-    socket.emit(BLOCK_EVENT.CREATE_VOTE, id, validOptions);
+    socket.emit(BLOCK_EVENT.REGISTER_VOTE, id, validOptions);
 
     toast('투표 등록 완료 ^^', { type: 'info' });
   };

--- a/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
+++ b/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
@@ -30,8 +30,9 @@ function VoteBlockTemplate({
   options,
   setOptions,
 }: VoteBlockProps) {
-  const [isCreateMode, isRegisteredMode, isEndMode] = [
+  const [isCreateMode, isRegisteringMode, isRegisteredMode, isEndMode] = [
     mode === VoteMode.CREATE,
+    mode === VoteMode.REGISTERING,
     mode === VoteMode.REGISTERED,
     mode === VoteMode.END,
   ];
@@ -182,7 +183,7 @@ function VoteBlockTemplate({
               readOnly={isRegisteredMode || isEndMode}
               defaultValue={text}
             />
-            {isCreateMode && (
+            {isRegisteringMode && (
               <Button
                 icon={<BiX size="20" color="white" />}
                 ariaLabel="항목 삭제"
@@ -199,7 +200,7 @@ function VoteBlockTemplate({
       </ul>
 
       <div className={style['vote-buttons']}>
-        {isCreateMode && (
+        {isRegisteringMode && (
           <>
             <Button onClick={onAdd} text="항목 추가" />
             <Button onClick={onRegister} text="투표 등록" />

--- a/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
+++ b/client/src/components/Block/VoteBlock/VoteBlockTemplate.tsx
@@ -144,61 +144,65 @@ function VoteBlockTemplate({
 
   return (
     <div className={style['vote-container']}>
-      <h3 className={style.title}>투표</h3>
+      <h3 className={style.title}>
+        {isCreateMode ? '투표 등록중 ^^' : '투표'}
+      </h3>
       {(isRegisteredMode || isEndMode) && (
         <span className={style['participant-cnt']}>
           {participantCount}명 참여
         </span>
       )}
-
-      <ul>
-        {options.map(({ id, text, count }, index) => (
-          <li
-            className={cx('option-item', {
-              'selected-item':
-                (isRegisteredMode || isEndMode) && id === selectedOptionId,
-            })}
-            key={id}
-            onClick={() => onSelect(id)}
-          >
-            {isEndMode && (
-              <div
-                className={style['vote-result-bar']}
-                style={{
-                  width: `${getPercent(count)}%`,
-                  backgroundColor: color.highlight100,
-                }}
-              ></div>
-            )}
-
-            <div className={style['box-fill']}>{index + 1}</div>
-            <input
-              type="text"
-              className={cx('option-input', {
-                selected: isRegisteredMode,
+      {isCreateMode ? (
+        <></>
+      ) : (
+        <ul>
+          {options.map(({ id, text, count }, index) => (
+            <li
+              className={cx('option-item', {
+                'selected-item':
+                  (isRegisteredMode || isEndMode) && id === selectedOptionId,
               })}
-              placeholder="항목을 입력해주세요"
-              onChange={onChange}
-              data-id={id}
-              readOnly={isRegisteredMode || isEndMode}
-              defaultValue={text}
-            />
-            {isRegisteringMode && (
-              <Button
-                icon={<BiX size="20" color="white" />}
-                ariaLabel="항목 삭제"
-                onClick={() => onDelete(id)}
-              />
-            )}
-            {isEndMode && (
-              <div className={style['vote-result-text']}>
-                {getVoteResultText(count)}
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
+              key={id}
+              onClick={() => onSelect(id)}
+            >
+              {isEndMode && (
+                <div
+                  className={style['vote-result-bar']}
+                  style={{
+                    width: `${getPercent(count)}%`,
+                    backgroundColor: color.highlight100,
+                  }}
+                ></div>
+              )}
 
+              <div className={style['box-fill']}>{index + 1}</div>
+              <input
+                type="text"
+                className={cx('option-input', {
+                  selected: isRegisteredMode,
+                })}
+                placeholder="항목을 입력해주세요"
+                onChange={onChange}
+                data-id={id}
+                readOnly={isRegisteredMode || isEndMode}
+                defaultValue={text}
+              />
+              {isRegisteringMode && (
+                <Button
+                  icon={<BiX size="20" color="white" />}
+                  ariaLabel="항목 삭제"
+                  onClick={() => onDelete(id)}
+                />
+              )}
+              {isEndMode && (
+                <div className={style['vote-result-text']}>
+                  {getVoteResultText(count)}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
       <div className={style['vote-buttons']}>
         {isRegisteringMode && (
           <>

--- a/client/src/components/Block/VoteBlock/index.tsx
+++ b/client/src/components/Block/VoteBlock/index.tsx
@@ -18,7 +18,7 @@ function VoteBlock({ id }: VoteBlockProps) {
   const [options, setOptions] = useState<Option[]>(initialOption);
 
   useEffect(() => {
-    socket.on(`${BLOCK_EVENT.CREATE_VOTE}-${id}`, (options) => {
+    socket.on(`${BLOCK_EVENT.REGISTER_VOTE}-${id}`, (options) => {
       setVoteMode(VoteMode.REGISTERED as VoteMode);
       setOptions(options);
     });

--- a/client/src/components/Block/VoteBlock/index.tsx
+++ b/client/src/components/Block/VoteBlock/index.tsx
@@ -8,12 +8,15 @@ import VoteBlockTemplate from './VoteBlockTemplate';
 
 interface VoteBlockProps {
   id: string;
+  registerable: boolean;
 }
 
-function VoteBlock({ id }: VoteBlockProps) {
+function VoteBlock({ id, registerable }: VoteBlockProps) {
   const { momSocket: socket } = useSocketContext();
 
-  const [voteMode, setVoteMode] = useState<VoteMode>(VoteMode.CREATE);
+  const [voteMode, setVoteMode] = useState<VoteMode>(
+    registerable ? VoteMode.REGISTERING : VoteMode.CREATE,
+  );
   const initialOption: Option[] = [{ id: 1, text: '', count: 0 }];
   const [options, setOptions] = useState<Option[]>(initialOption);
 

--- a/client/src/components/Block/index.tsx
+++ b/client/src/components/Block/index.tsx
@@ -65,7 +65,7 @@ function Block({ id, index, onKeyDown, registerRef }: BlockProps) {
         />
       );
     case BlockType.VOTE:
-      return <VoteBlock id={id} />;
+      return <VoteBlock id={id} registerable={localUpdateFlagRef.current} />;
     case BlockType.QUESTION:
       return <QuestionBlock id={id} />;
     default:

--- a/client/src/components/Mom/index.tsx
+++ b/client/src/components/Mom/index.tsx
@@ -149,8 +149,8 @@ function Mom() {
       setBlocks(spreadCRDT());
     });
 
-    socket.on(BLOCK_EVENT.INIT, (id, crdt) => {
-      ee.emit(`${BLOCK_EVENT.INIT}-${id}`, crdt);
+    socket.on(BLOCK_EVENT.INIT_TEXT, (id, crdt) => {
+      ee.emit(`${BLOCK_EVENT.INIT_TEXT}-${id}`, crdt);
     });
 
     socket.on(BLOCK_EVENT.INSERT_TEXT, (id, op) => {
@@ -176,7 +176,7 @@ function Mom() {
         MOM_EVENT.UPDATED,
         MOM_EVENT.INSERT_BLOCK,
         MOM_EVENT.DELETE_BLOCK,
-        BLOCK_EVENT.INIT,
+        BLOCK_EVENT.INIT_TEXT,
         BLOCK_EVENT.INSERT_TEXT,
         BLOCK_EVENT.DELETE_TEXT,
         BLOCK_EVENT.UPDATE_TYPE,

--- a/client/src/constants/block.ts
+++ b/client/src/constants/block.ts
@@ -39,6 +39,7 @@ export const BLOCKS_TYPE = [
 
 export enum VoteMode {
   CREATE,
+  REGISTERING,
   REGISTERED,
   END,
 }

--- a/server/socket/Mom/handleTextBlock.ts
+++ b/server/socket/Mom/handleTextBlock.ts
@@ -6,10 +6,10 @@ export default function handleTextBlock(
   socket: Socket,
   crdtManager: CrdtManager,
 ) {
-  socket.on(BLOCK_EVENT.INIT, async (blockId) => {
+  socket.on(BLOCK_EVENT.INIT_TEXT, async (blockId) => {
     const blockCrdt = await crdtManager.getBlockCRDT(blockId);
 
-    socket.emit(BLOCK_EVENT.INIT, blockId, blockCrdt.data);
+    socket.emit(BLOCK_EVENT.INIT_TEXT, blockId, blockCrdt.data);
   });
 
   socket.on(BLOCK_EVENT.INSERT_TEXT, async (blockId, op) => {
@@ -22,7 +22,7 @@ export default function handleTextBlock(
     } catch {
       const blockCrdt = await crdtManager.getBlockCRDT(blockId);
 
-      socket.emit(BLOCK_EVENT.INIT, blockId, blockCrdt.data);
+      socket.emit(BLOCK_EVENT.INIT_TEXT, blockId, blockCrdt.data);
     }
   });
 
@@ -36,7 +36,7 @@ export default function handleTextBlock(
     } catch {
       const blockCrdt = await crdtManager.getBlockCRDT(blockId);
 
-      socket.emit(BLOCK_EVENT.INIT, blockId, blockCrdt.data);
+      socket.emit(BLOCK_EVENT.INIT_TEXT, blockId, blockCrdt.data);
     }
   });
 

--- a/server/socket/Mom/handleVoteBlock.ts
+++ b/server/socket/Mom/handleVoteBlock.ts
@@ -12,12 +12,12 @@ export default function handleVoteBlock(
   namespace: string,
   socket: Socket,
 ) {
-  socket.on(BLOCK_EVENT.CREATE_VOTE, async (blockId, options: Option[]) => {
+  socket.on(BLOCK_EVENT.REGISTER_VOTE, async (blockId, options: Option[]) => {
     const momId = socket.data.momId;
 
     await createVote(blockId, options);
 
-    socket.to(momId).emit(`${BLOCK_EVENT.CREATE_VOTE}-${blockId}`, options);
+    socket.to(momId).emit(`${BLOCK_EVENT.REGISTER_VOTE}-${blockId}`, options);
   });
 
   socket.on(BLOCK_EVENT.UPDATE_VOTE, async (blockId, optionId, userId) => {


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #300 
- 투표 블럭을 생성한 사람만 투표를 등록할 수 있도록 했어요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- #304 에 이어지는 작업이에요.
- 일단 돌아가게만 되어있는 작업입니다 ^^... 브랜치 가져가서 개선해주셔도 돼요.
  - 투표가 등록되었을 때 투표 블럭이 생성되는 기획서 상의 방식으로는 다른 클라이언트가 또 다시 타입을 수정할 여지가 있어 블럭 타입 관리에 어려움이 생김

  - 블럭 타입은 선택 시점에 변경되도록 하되, 투표가 등록되기 전에는 시작되지 않았음을 UI로 확인할 수 있도록 수정

  - 투표를 등록할 수 있는지 확인하기 위해 `Block` 컴포넌트의 타입 변경에 사용되는 localUpdateFlagRef.current 값을 사용
    - 🫠 블럭을 생성한 사람이 등록하지 않고 새로고침하면 해당 투표 블럭을 사용할 수 없게됩니다
      - 이건 알아서 삭제하고 새로 만들라고 할까요 ^^...

- [ ] **`TBD:`** `VoteBlock` 마운트 시에 INIT_VOTE 이벤트를 통해서 해당 투표 정보를 가져오는 로직 추가
  - 현재 투표 블럭에 대한 로직이 접속 중인 클라이언트들 끼리만 반영되도록 되어있어요.
  - `VoteBlock` 컴포넌트가 해당 블럭의 정보를 로드해오는 부분이 필요합니다.
  - **이 작업을 위해서 `VoteBlockTemplate`에 투표 정보 자체를 주입하도록 변경할 것 같아요.**
    ```ts
    function VoteBlockTemplate({
      id,
      mode,
      setVoteMode,
      options,
      setOptions,
    }: VoteBlockProps) {
      // 생략
      const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null);
      const [participantCount, setParticipantCount] = useState(0);
    ```
    - `VoteBlock`에서는 사용하지 않는 상태, 상태 변경 함수들을 `VoteBlockTemplate`에 props로 전달하는데 둘의 역할을 분리해볼게요.
    - (아마도) `VoteBlockTemplate`은 템플릿으로 기능하도록, 정보를 주입하면 그것만 보여주게 해볼게요.

- [X] **`TBD:`** `VoteBlockTemplate` jsx 부분 수정
  - mode가 늘어나서 지저분해졌는데 나중에 개선할게요 ...
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/63814960/206836591-0ba67009-eaca-493d-b507-ff823cb38ee3.png">

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/63814960/206836132-b1a1bae7-71a5-478b-ae06-7df63bb42b9d.mov
