### PR TITLE
Refactor/#301-B: useOffset 훅, Mom, Block 컴포넌트 핸들러 네이밍 구체화

### DIFF
--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -15,7 +15,7 @@ import ee from '../Mom/EventEmitter';
 interface BlockProps {
   id: string;
   index: number;
-  onKeyDown: React.KeyboardEventHandler;
+  onHandleBlock: React.KeyboardEventHandler;
   type: BlockType;
   setType: (arg: BlockType) => void;
   registerRef: (arg: React.RefObject<HTMLElement>) => void;
@@ -24,7 +24,7 @@ interface BlockProps {
 function TextBlock({
   id,
   index,
-  onKeyDown,
+  onHandleBlock,
   type,
   setType,
   registerRef,
@@ -43,7 +43,7 @@ function TextBlock({
 
   const blockRef = useRef<HTMLParagraphElement>(null);
 
-  const { offsetRef, setOffset, clearOffset, offsetHandlers } =
+  const { offsetRef, setOffset, clearOffset, onArrowKeyDown, offsetHandlers } =
     useOffset(blockRef);
 
   // 리모트 연산 수행결과로 innerText 변경 시 커서의 위치 조정
@@ -205,11 +205,9 @@ function TextBlock({
     updateCaretPosition(pastedText.length);
   };
 
-  const onKeyDownComposite: React.KeyboardEventHandler<HTMLParagraphElement> = (
-    e,
-  ) => {
-    offsetHandlers.onKeyDown(e);
-    onKeyDown(e);
+  const onKeyDown: React.KeyboardEventHandler<HTMLParagraphElement> = (e) => {
+    onArrowKeyDown(e);
+    onHandleBlock(e);
   };
 
   const onBlur = () => {
@@ -221,7 +219,7 @@ function TextBlock({
     onInput,
     onCompositionEnd,
     ...offsetHandlers,
-    onKeyDown: onKeyDownComposite,
+    onKeyDown,
     onPaste,
     onBlur,
   };

--- a/client/src/components/Mom/index.tsx
+++ b/client/src/components/Mom/index.tsx
@@ -71,7 +71,7 @@ function Mom() {
     range.collapse();
   };
 
-  const onKeyDown: React.KeyboardEventHandler = (e) => {
+  const onHandleBlock: React.KeyboardEventHandler = (e) => {
     const target = e.target as HTMLParagraphElement;
 
     const { index: indexString } = target.dataset;
@@ -205,7 +205,7 @@ function Mom() {
               key={id}
               id={id}
               index={index}
-              onKeyDown={onKeyDown}
+              onHandleBlock={onHandleBlock}
               registerRef={(ref: React.RefObject<HTMLElement>) => {
                 blockRefs.current[index] = ref;
               }}

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -43,7 +43,7 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
     }
   };
 
-  // 위 아래 방향키 이동은 핸들링하지 않음
+  // 위 아래 방향키 이동은 keyDown에서 핸들링하지 않음
   const onArrowKeyup: React.KeyboardEventHandler = (e) => {
     const ARROW_DOWN = 'ArrowDown';
     const ARROW_UP = 'ArrowUp';

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -29,7 +29,7 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   };
 
   // keydown 이벤트는 키 입력의 내용 반영 이전에 발생
-  const onKeyDown: React.KeyboardEventHandler = (e) => {
+  const onArrowKeyDown: React.KeyboardEventHandler = (e) => {
     const ARROW_LEFT = 'ArrowLeft';
     const ARROW_RIGHT = 'ArrowRight';
 
@@ -44,7 +44,7 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   };
 
   // 위 아래 방향키 이동은 핸들링하지 않음
-  const onKeyUp: React.KeyboardEventHandler = (e) => {
+  const onArrowKeyup: React.KeyboardEventHandler = (e) => {
     const ARROW_DOWN = 'ArrowDown';
     const ARROW_UP = 'ArrowUp';
 
@@ -58,14 +58,14 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
       setOffset as unknown as React.FocusEventHandler<HTMLParagraphElement>,
     onClick:
       setOffset as unknown as React.MouseEventHandler<HTMLParagraphElement>,
-    onKeyDown,
-    onKeyUp,
+    onKeyUp: onArrowKeyup,
   };
 
   return {
     offsetRef,
     setOffset,
     clearOffset,
+    onArrowKeyDown,
     offsetHandlers,
   };
 }


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #302 변경과 기존에 사용하던 핸들러들의 컨벤션을 맞춰봐요.
- 회의록과 블럭 쪽 코드는 읽기 복잡해요. 엘리먼트에 붙이기 전에는 어떤 이벤트 핸들링을 해주는지 네이밍으로 알 수 있도록해요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)