### PR TITLE
Fix/#317-K: 회의록 createdAt 고정값으로 들어가는 이슈

### DIFF
--- a/server/apis/mom/model.ts
+++ b/server/apis/mom/model.ts
@@ -9,13 +9,15 @@ export interface Mom extends LinkedList {
   createdAt: Date;
 }
 
-const momSchema = new Schema<Mom>({
-  id: { type: Number, required: true },
-  title: { type: String, default: '제목 없음' },
-  createdAt: { type: Date, default: new Date() },
-  head: { type: Object, default: null },
-  nodeMap: { type: Object, default: {} },
-});
+const momSchema = new Schema<Mom>(
+  {
+    id: { type: Number, required: true },
+    title: { type: String, default: '제목 없음' },
+    head: { type: Object, default: null },
+    nodeMap: { type: Object, default: {} },
+  },
+  { timestamps: true },
+);
 
 momSchema.plugin(autoIncrement.plugin, {
   model: 'mom',


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Closes #317 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 정의할 때 new Date()가 실행되어 default 값이 고정이었던 mongoose 스키마를 수정했어요.

- @dohun31 님이 알려주신 `timestamps: true` 옵션을 사용했어요.