### PR TITLE
Fix/#321-K: 블럭 타입 선택 모달 닫는 기능에 dimmer 활용

### DIFF
--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -30,7 +30,6 @@ function TextBlock({
   registerRef,
 }: BlockProps) {
   const { momSocket: socket } = useSocketContext();
-  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const {
     syncCRDT,
@@ -45,6 +44,9 @@ function TextBlock({
 
   const { offsetRef, setOffset, clearOffset, onArrowKeyDown, offsetHandlers } =
     useOffset(blockRef);
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const onClose = () => setIsOpen(false);
 
   // 리모트 연산 수행결과로 innerText 변경 시 커서의 위치 조정
   const updateCaretPosition = (updateOffset = 0) => {
@@ -212,18 +214,12 @@ function TextBlock({
     onHandleBlock(e);
   };
 
-  const onBlur = () => {
-    clearOffset();
-    setIsOpen(false);
-  };
-
   const commonHandlers = {
     onInput,
     onCompositionEnd,
     ...offsetHandlers,
     onKeyDown,
     onPaste,
-    onBlur,
   };
 
   const BLOCK_TYPES = Object.values(BlockType)
@@ -249,7 +245,7 @@ function TextBlock({
         },
         readCRDT(),
       )}
-      {isOpen && <BlockSelector onSelect={onSelect} />}
+      {isOpen && <BlockSelector onClose={onClose} onSelect={onSelect} />}
     </>
   );
 }

--- a/client/src/components/BlockSelector/index.tsx
+++ b/client/src/components/BlockSelector/index.tsx
@@ -5,22 +5,29 @@ import BlockItem from './BlockItem';
 import style from './style.module.scss';
 
 interface BlockSelectorProps {
+  onClose: () => void;
   onSelect: (arg: BlockType) => void;
 }
 
-function BlockSelector({ onSelect }: BlockSelectorProps) {
+function BlockSelector({ onClose, onSelect }: BlockSelectorProps) {
   return (
-    <div className={style['block-selector']}>
-      <div className={style['block-displayed']}>
-        <strong>블록</strong>
+    <>
+      <div className={style['block-selector']}>
+        <div className={style['block-displayed']}>
+          <strong>블록</strong>
 
-        <ul className={style['block-list']}>
-          {BLOCKS_TYPE.map(({ id, name, desc, thumbnail }) => (
-            <BlockItem key={id} {...{ id, name, desc, thumbnail, onSelect }} />
-          ))}
-        </ul>
+          <ul className={style['block-list']}>
+            {BLOCKS_TYPE.map(({ id, name, desc, thumbnail }) => (
+              <BlockItem
+                key={id}
+                {...{ id, name, desc, thumbnail, onSelect }}
+              />
+            ))}
+          </ul>
+        </div>
       </div>
-    </div>
+      <div className={style['dimmer']} onClick={onClose}></div>
+    </>
   );
 }
 

--- a/client/src/components/BlockSelector/style.module.scss
+++ b/client/src/components/BlockSelector/style.module.scss
@@ -3,7 +3,7 @@
 .block-selector {
   position: absolute;
   z-index: 99;
-  height: 100%;
+  height: 280px;
   overflow: hidden;
 
   .block-displayed {
@@ -26,4 +26,12 @@
       font-size: 12px;
     }
   }
+}
+
+.dimmer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
 }

--- a/client/src/hooks/useOffset.tsx
+++ b/client/src/hooks/useOffset.tsx
@@ -54,8 +54,8 @@ export function useOffset(blockRef: React.RefObject<HTMLParagraphElement>) {
   };
 
   const offsetHandlers = {
-    onClick:
-      setOffset as unknown as React.MouseEventHandler<HTMLParagraphElement>,
+    onClick: setOffset,
+    onBlur: clearOffset,
     onKeyUp: onArrowKeyup,
   };
 


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Resolves #321
- 블럭 타입 모달에서 타입 변경하는 기능이 제대로 작동하지 않아서 모달에 dimmer layer를 추가했어요.

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- dimmer layer 하나를 두고 모달이 켜진 상태에서 외부 영역을 클릭하면 모달이 닫히도록 했어요
- Problem: 다른 블럭으로 이동하려면 더블 클릭이 필요해요.
  - 모달이 닫히는 방식을 바꾸면서 발생한 문제인데 더 좋은 방법이 생각나면 개선할게요.
  - 수정 전 코드에서 onBlur 이벤트를 onFocusOut으로 사용하면 정상적으로 동작하는데, 리액트에서 사용하지 않는 이벤트라고 엄청난 에러를 띄워서 포기했어요.