### PR TITLE
Chore: CI 캐싱 key 충돌 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      
       - name: Use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -28,7 +29,7 @@ jobs:
         if: runner.os != 'Windows'
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Cache dependencies
         id: cache
         uses: actions/cache@v3
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' # 윈도우는 이슈가 있어 캐싱 건너 뜀 (#325 참고)
         with:
           path: '**/node_modules'
           key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## 🤠 개요

## 💫 설명

16, 18 버전이 같은 이름으로 캐싱 키를 만들기 때문에 캐시 저장 시 충돌이 일어날 때가 있습니다.

![image](https://user-images.githubusercontent.com/89635107/207047769-ac83def6-f6c6-4157-b5db-f1e1b21de343.png)

버전 별로 다른 캐시 키를 만들도록 수정했습니다.

윈도우에서 캐싱을 건너뛰는 이유(#325)를 코멘트로 달아놓았습니다.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)