### PR TITLE
Feat/#295-C: 캠/마이크 상태 전달을 위한 소켓 이벤트 핸들링

### DIFF
--- a/server/socket/workspace.ts
+++ b/server/socket/workspace.ts
@@ -43,6 +43,15 @@ function workspaceSocketServer(io: Server) {
       socket.to(receiverId).emit(WORKSPACE_EVENT.RECEIVE_ICE, ice, senderId);
     });
 
+    // TODO: 소켓 이벤트 메시지 상수화
+    socket.on('audio_state_changed', (videoOn) => {
+      namespace.emit('audio_state_changed', socket.id, videoOn);
+    });
+
+    socket.on('video_state_changed', (videoOn) => {
+      namespace.emit('video_state_changed', socket.id, videoOn);
+    });
+
     socket.on('disconnecting', () => {
       const senderId = socket.id;
       socket.broadcast.emit(WORKSPACE_EVENT.RECEIVE_BYE, senderId);

--- a/server/socket/workspace.ts
+++ b/server/socket/workspace.ts
@@ -44,8 +44,8 @@ function workspaceSocketServer(io: Server) {
     });
 
     // TODO: 소켓 이벤트 메시지 상수화
-    socket.on('audio_state_changed', (videoOn) => {
-      namespace.emit('audio_state_changed', socket.id, videoOn);
+    socket.on('audio_state_changed', (audioOn) => {
+      namespace.emit('audio_state_changed', socket.id, audioOn);
     });
 
     socket.on('video_state_changed', (videoOn) => {


### PR DESCRIPTION
## 🤠 개요

- resolves #295

<!-- 

- 이슈번호
- 한줄 설명
 
-->

[`useMeetingMediaStreamsV2`](https://github.com/boostcampwm-2022/web27-Wabinar/blob/d8ec80d7ccda24a644b6664e2ba4c79056df183f/client/src/hooks/useMeetingMediaStreamsV2.tsx) 훅(#294)에서 사용할 이벤트(`audio_state_changed`, `video_state_changed`)를 백엔드에서 지원합니다.

https://github.com/boostcampwm-2022/web27-Wabinar/blob/d8ec80d7ccda24a644b6664e2ba4c79056df183f/client/src/hooks/useMeetingMediaStreamsV2.tsx#L66-L80

## 💫 설명

다음 이슈를 위한 서브 이슈(#295)를 해결하는 PR입니다.

- #254

캠/마이크 상태를 피어들도 알 수 있도록 웹소켓을 통해 피어들에게 메시지를 전달합니다.

<!-- 

- 현재 Pr 설명 

-->

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)