### PR TITLE
Feat/#254-C: 피어가 캠/마이크 조작 시 아이콘 변경

### DIFF
--- a/client/src/components/MeetingMediaBar/index.tsx
+++ b/client/src/components/MeetingMediaBar/index.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
-import { useMeetingMediaStreams } from 'src/hooks/useMeetingMediaStreams';
+import {
+  useMeetingMediaStreamsV2,
+  MeetingMediaStream,
+} from 'src/hooks/useMeetingMediaStreamsV2';
 import useSocketContext from 'src/hooks/useSocketContext';
 
 import MeetingMedia from './MeetingMedia';
@@ -8,35 +11,33 @@ import style from './style.module.scss';
 
 function MeetingMediaBar() {
   const { workspaceSocket: socket } = useSocketContext();
-  const [streams, setMyTrack] = useMeetingMediaStreams(socket);
+  const [streams, setLocalAudio, setLocalVideo] =
+    useMeetingMediaStreamsV2(socket);
 
   const [isMicOn, setIsMicOn] = useState(true);
   const [isCamOn, setIsCamOn] = useState(true);
 
   useEffect(() => {
-    setMyTrack('audio', isMicOn);
+    setLocalAudio(isMicOn);
   }, [isMicOn]);
 
   useEffect(() => {
-    setMyTrack('video', isCamOn);
+    setLocalVideo(isCamOn);
   }, [isCamOn]);
 
   return (
     <div className={style['meeting-bar']}>
       <ul>
-        {Array.from(streams).map(([id, stream]) => (
-          <li key={id}>
-            <MeetingMedia
-              key={id}
-              stream={stream}
-              muted={id === 'me' ? true : false}
-            />
-            <StreamButton
-              isMicOn={false}
-              isCamOn={true} // TODO: 임시로 지정
-            />
-          </li>
-        ))}
+        {streams.map(
+          ({ id, stream, type, audioOn, videoOn }: MeetingMediaStream) => (
+            <li key={id}>
+              <MeetingMedia key={id} stream={stream} muted={type === 'local'} />
+              {type === 'remote' && (
+                <StreamButton isMicOn={audioOn} isCamOn={videoOn} />
+              )}
+            </li>
+          ),
+        )}
       </ul>
       <StreamButton
         {...{

--- a/client/src/components/MeetingMediaBar/index.tsx
+++ b/client/src/components/MeetingMediaBar/index.tsx
@@ -31,7 +31,7 @@ function MeetingMediaBar() {
         {streams.map(
           ({ id, stream, type, audioOn, videoOn }: MeetingMediaStream) => (
             <li key={id}>
-              <MeetingMedia key={id} stream={stream} muted={type === 'local'} />
+              <MeetingMedia stream={stream} muted={type === 'local'} />
               {type === 'remote' && (
                 <StreamButton isMicOn={audioOn} isCamOn={videoOn} />
               )}

--- a/server/socket/workspace.ts
+++ b/server/socket/workspace.ts
@@ -43,6 +43,15 @@ function workspaceSocketServer(io: Server) {
       socket.to(receiverId).emit(WORKSPACE_EVENT.RECEIVE_ICE, ice, senderId);
     });
 
+    // TODO: 소켓 이벤트 메시지 상수화
+    socket.on('audio_state_changed', (videoOn) => {
+      namespace.emit('audio_state_changed', socket.id, videoOn);
+    });
+
+    socket.on('video_state_changed', (videoOn) => {
+      namespace.emit('video_state_changed', socket.id, videoOn);
+    });
+
     socket.on('disconnecting', () => {
       const senderId = socket.id;
       socket.broadcast.emit(WORKSPACE_EVENT.RECEIVE_BYE, senderId);


### PR DESCRIPTION
## 🤠 개요

- resolves #254

## 💫 설명

`useMeetingMediaStreamsV2` 훅(#294)을 사용합니다.
이 인터페이스에는 피어들의 캠/마이크 상태가 들어있는 `streams`를 받을 수 있습니다.

피어들에게 캠/마이크 조작 이벤트를 받으면 그에 맞는 아이콘을 렌더링합니다.
자신의 캠/마이크 상태는 아래 조작 버튼으로 알 수 있기 때문에 이것으로 대신하고 화상 회의에서는 표시하지 않습니다.

## 🌜 고민거리 (Optional)

관련 내용은 아니지만 이 기능 추가 이후에 #282 해결 방법을 생각하고 있습니다.

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/89635107/207215955-8a724a54-e16e-488a-964e-578f8038c0d3.mp4

