### PR TITLE
Perf/#348-B: 불필요한 리렌더링 방지

### DIFF
--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -1,7 +1,7 @@
 import { WORKSPACE_EVENT } from '@wabinar/constants/socket-message';
 import Mom from 'components/Mom';
 import Sidebar from 'components/Sidebar';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getWorkspaceInfo } from 'src/apis/workspace';
 import MeetingMediaBar from 'src/components/MeetingMediaBar';
@@ -56,11 +56,21 @@ function Workspace() {
     };
   }, [workspaceSocket]);
 
+  const memoizedSocketValue = useMemo(
+    () => ({ momSocket, workspaceSocket }),
+    [momSocket, workspaceSocket],
+  );
+
+  const memoizedOnGoingValue = useMemo(
+    () => ({ isOnGoing, setIsOnGoing }),
+    [isOnGoing],
+  );
+
   if (!momSocket || !workspaceSocket) return <></>;
 
   return (
-    <SocketContext.Provider value={{ momSocket, workspaceSocket }}>
-      <MeetingContext.Provider value={{ isOnGoing, setIsOnGoing }}>
+    <SocketContext.Provider value={memoizedSocketValue}>
+      <MeetingContext.Provider value={memoizedOnGoingValue}>
         {workspace && (
           <SelectedMomContext.Provider value={{ selectedMom, setSelectedMom }}>
             <Sidebar workspace={workspace} />


### PR DESCRIPTION


## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #348 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- #182 에서 해결했었는데 #288 에서 `useSocket`이 변경되고 다시 리렌더링 되기 시작했어요.
  - 원인은 `MomList`에서 `useSocketContext`를 사용하는데 아마 socket이 새로 바껴서 시작해서 그런것 같아요.
  - Context.Provider에서 value를 전달할 때 value에서 바로 선언해서 전달하면 `Workspace`가 변경될 때마다 value에 새로운 변수로 만들어져서 밖에서 선언하도록 했어요.
  - 이때 `useMemo`를 사용했어요.

- **아무것도 안했을 때**
  ```ts
  return (
    <SocketContext.Provider value={{ momSocket, workspaceSocket }}>
      <MeetingContext.Provider value={{ isOnGoing, setIsOnGoing }}>
        {workspace && (
  ```
  https://user-images.githubusercontent.com/65100540/207248675-989aa6b0-9bcc-460f-80a2-2586cd69d4eb.mov

- **`memoizedSocketValue`했을 때**
  ```ts
  return (
    <SocketContext.Provider value={memoizedSocketValue}>
      <MeetingContext.Provider value={{ isOnGoing, setIsOnGoing }}>
        {workspace && (
  ```

  - `MeetingButton`에서 `useMeetingContext`를 사용하고 있어요.
  - `isOnGoing`은 여전히 `false`이지만 selectedMom이 변경될 때 `MeetingContext.Provider value={{ isOnGoing, setIsOnGoing }}>`에서 똑같은 값이지만 다른 객체(주소)가 되어서 Context가 변경되었다고 착각해요.
  - 그래서 얘도 memo해줘야 해요.
  
  https://user-images.githubusercontent.com/65100540/207248824-c42e715c-2641-4b6e-bcbd-98034fa48117.mov



- **`memoizedSocketValue` + `memoizedOnGoingValue`**

```ts
  return (
    <SocketContext.Provider value={memoizedSocketValue}>
      <MeetingContext.Provider value={{ memoizedOnGoingValue }}>
        {workspace && (
```

짜잔!

이제 원하는 대로 됐어요!

https://user-images.githubusercontent.com/65100540/207249610-84da658b-f1a9-4f0c-a3f5-4a0f9a1bc1b6.mov


## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)