### PR TITLE
Perf/#352-B: font 불러오는 시간 개선 (FCP)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wabinar</title>
   </head>

--- a/client/src/styles/reset.scss
+++ b/client/src/styles/reset.scss
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: 'Noto Sans KR';
+  src: url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
+}
+
 html,
 body,
 div,
@@ -79,13 +84,13 @@ time,
 mark,
 audio,
 video {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   border: 0;
-  font-size: 100%;
   font: inherit;
+  font-size: 100%;
   vertical-align: baseline;
-  box-sizing: border-box;
 }
 
 article,
@@ -104,9 +109,9 @@ section {
 }
 
 body {
-  line-height: normal;
   font-family: 'Noto Sans KR', sans-serif;
   font-weight: 400;
+  line-height: normal;
 }
 ol,
 ul {
@@ -124,8 +129,8 @@ q:after {
   content: none;
 }
 table {
-  border-collapse: collapse;
   border-spacing: 0;
+  border-collapse: collapse;
 }
 
 input,
@@ -149,7 +154,7 @@ textarea {
 
 button {
   padding: 0;
-  background-color: transparent;
   border: none;
+  background-color: transparent;
   cursor: pointer;
 }


### PR DESCRIPTION


## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #352 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- html에서 font를 import해오고 있는데 얘가 다 불러오기 전까지 body가 그려지지 않아서 FCP 시간이 오래걸려요.

  <img width="795" alt="스크린샷 2022-12-13 오후 5 01 05" src="https://user-images.githubusercontent.com/65100540/207263942-633eef5c-cb90-404f-8604-2b6b2ff6f433.png">

  - 그래서 폰트를 css에서 불러오도록 했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)
- 배포 버전
  - 제일 먼저 불러와서 FCP 시간이 느려짐
<img width="900" alt="스크린샷 2022-12-13 오후 5 17 08" src="https://user-images.githubusercontent.com/65100540/207264054-395f1ba9-e99f-470f-a61e-b21d137aee42.png">


- css에서 불러올 때
  - 폰트를 불러오는 타이밍이 뒤로 밀림
<img width="747" alt="스크린샷 2022-12-13 오후 5 15 32" src="https://user-images.githubusercontent.com/65100540/207264113-94e06d53-25a3-4fb8-af9a-b57e22c2785b.png">
