### PR TITLE
Test/C: CRDT 테스트 케이스 수정 및 예외 케이스 추가

### DIFF
--- a/@wabinar/crdt/linked-list.ts
+++ b/@wabinar/crdt/linked-list.ts
@@ -111,11 +111,15 @@ export default class LinkedList {
 
       const prevNode = this.findByIndex(index - 1);
 
-      if (!prevNode.next) return null;
+      if (!prevNode.next) {
+        throw new Error('deleteByIndex 실패 ^^');
+      }
 
       const targetNode = this.getNode(prevNode.next);
 
-      if (!targetNode) return null;
+      if (!targetNode) {
+        throw new Error('deleteByIndex 실패 ^^');
+      }
 
       this.deleteNode(targetNode.id);
       prevNode.next = targetNode.next;

--- a/@wabinar/crdt/test/crdt.test.ts
+++ b/@wabinar/crdt/test/crdt.test.ts
@@ -7,31 +7,31 @@ describe('CRDT Local operations', () => {
   beforeEach(() => {
     const initialStructure = new LinkedList();
     나 = new CRDT(1, initialStructure);
-  })
+  });
 
   describe('localInsert()', () => {
     it('head 위치 삽입에 성공한다.', () => {
       // act
       나.localInsert(-1, '녕');
       나.localInsert(-1, '안');
-  
+
       // assert
       expect(나.read()).toEqual('안녕');
     });
-  
+
     it('tail 위치 삽입에 성공한다.', () => {
       // act
       나.localInsert(-1, '안');
       나.localInsert(0, '녕');
-  
+
       // assert
       expect(나.read()).toEqual('안녕');
     });
-  
+
     it('없는 위치에 삽입 시도 시 에러를 던진다.', () => {
       // arrange
       나.localInsert(-1, '안');
-      
+
       // act & assert
       expect(() => 나.localInsert(1, '녕')).toThrow();
     });
@@ -45,17 +45,17 @@ describe('CRDT Local operations', () => {
 
       // act
       나.localDelete(1);
-  
+
       // assert
       expect(나.read()).toEqual('안');
     });
-  
+
     it('없는 위치에 삭제 시도 시 에러를 던진다.', () => {
       // arrange
       나.localInsert(-1, '안');
-  
+
       // act & assert
-      expect(() => 나.localInsert(1, '녕')).toThrow();
+      expect(() => 나.localDelete(1)).toThrow();
     });
   });
 });

--- a/@wabinar/crdt/test/crdt.test.ts
+++ b/@wabinar/crdt/test/crdt.test.ts
@@ -1,34 +1,61 @@
 import CRDT from '../index';
 import LinkedList from '../linked-list';
 
-describe('Local operation', () => {
-  const initialStructure = new LinkedList();
+describe('CRDT Local operations', () => {
+  let 나;
 
-  const 나 = new CRDT(1, initialStructure);
+  beforeEach(() => {
+    const initialStructure = new LinkedList();
+    나 = new CRDT(1, initialStructure);
+  })
 
-  it('head에 삽입', () => {
-    let innerText = 나.read();
-
-    나.localInsert(-1, '녕');
-    expect(나.read()).toEqual('녕' + innerText);
-
-    innerText = 나.read();
-
-    나.localInsert(-1, '안');
-    expect(나.read()).toEqual('안' + innerText);
+  describe('localInsert()', () => {
+    it('head 위치 삽입에 성공한다.', () => {
+      // act
+      나.localInsert(-1, '녕');
+      나.localInsert(-1, '안');
+  
+      // assert
+      expect(나.read()).toEqual('안녕');
+    });
+  
+    it('tail 위치 삽입에 성공한다.', () => {
+      // act
+      나.localInsert(-1, '안');
+      나.localInsert(0, '녕');
+  
+      // assert
+      expect(나.read()).toEqual('안녕');
+    });
+  
+    it('없는 위치에 삽입 시도 시 에러를 던진다.', () => {
+      // arrange
+      나.localInsert(-1, '안');
+      
+      // act & assert
+      expect(() => 나.localInsert(1, '녕')).toThrow();
+    });
   });
 
-  it('tail에 삽입', () => {
-    let innerText = 나.read();
+  describe('localDelete()', () => {
+    it('tail 위치 삭제에 성공한다.', () => {
+      // arrange
+      나.localInsert(-1, '안');
+      나.localInsert(0, '녕');
 
-    나.localInsert(1, '하');
-    expect(나.read()).toEqual(innerText + '하');
-  });
-
-  it('head 삭제', () => {
-    let innerText = 나.read();
-
-    나.localDelete(0);
-    expect(나.read()).toEqual(innerText.replace('안', ''));
+      // act
+      나.localDelete(1);
+  
+      // assert
+      expect(나.read()).toEqual('안');
+    });
+  
+    it('없는 위치에 삭제 시도 시 에러를 던진다.', () => {
+      // arrange
+      나.localInsert(-1, '안');
+  
+      // act & assert
+      expect(() => 나.localInsert(1, '녕')).toThrow();
+    });
   });
 });


### PR DESCRIPTION
## 🤠 개요

- #337 에서 작성한 케이스를 일부 수정했습니다.

## 💫 설명

### 테스트 케이스 이름에서 의도 드러내기

```ts
it('head에 삽입', /* ... */);
```
보다
```ts
it('head 위치 삽입에 성공한다.', /* ... */);
```
로 하면 테스트의 의도를 더 잘 설명해줄 수 있을 것 같아요.

### expect에서 의도 드러내기
```ts
expect(나.read()).toEqual('녕' + innerText);
```
보다
```ts
expect(나.read()).toEqual('안녕');
```
이 테스트에서 무엇을 기대하는지 쉽게 알 수 있을 것 같아요.

### 테스트 격리

매번 인스턴스를 준비하는게 귀찮다면 `beforeEach()` 등으로 자동화 할 수 있어요.

```ts
  beforeEach(() => {
    const initialStructure = new LinkedList();
    나 = new CRDT(1, initialStructure);
  })
```
는 각 테스트 케이스마다 깨끗한 `나` CRDT 인스턴스를 제공하도록 만듭니다.

### 실패 케이스

삽입과 삭제를 테스트 하고 있는데 실패 케이스도 추가했어요.

### 테스트 케이스 패턴

A-A-A 패턴 (또는 멘토님이 말씀해주신 given-when-then 패턴도 비슷) 참고하시면 이해하기 쉬운 테스트 케이스를 만들 수 있어요.

레퍼런스: https://codechacha.com/ko/unittest-aaa-pattern/

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)