### PR TITLE
Fix/#365-B: 폰트 불러오기 실패 해결

### DIFF
--- a/client/src/styles/reset.scss
+++ b/client/src/styles/reset.scss
@@ -1,8 +1,3 @@
-@font-face {
-  font-family: 'Noto Sans KR';
-  src: url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
-}
-
 html,
 body,
 div,


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Resolve: #365

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 신기한게 font를 따로 불러오지 않아도 원래 폰트 잘 적용돼요.
  - 그래서 괜히 load 시간만 차지하는것같아서 지웠어요.
  - safari와 chrome 폰트 동일한거까지 확인했어요

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)