### PR TITLE
Feat/#369-K: API 요청에 대한 권한 확인

### DIFF
--- a/@wabinar/api-types/auth.ts
+++ b/@wabinar/api-types/auth.ts
@@ -1,3 +1,9 @@
+import { User } from './user';
+
 export interface PostLoginBody {
   code: string;
+}
+
+export interface LoginResBody {
+  user: User;
 }

--- a/@wabinar/api-types/user.ts
+++ b/@wabinar/api-types/user.ts
@@ -1,5 +1,11 @@
 import { Workspace } from './workspace';
 
+export type User = {
+  id: number;
+  name: string;
+  avatarUrl: string;
+};
+
 export interface GetWorkspaceParams {
   id: number;
 }

--- a/client/src/apis/auth.ts
+++ b/client/src/apis/auth.ts
@@ -1,17 +1,9 @@
-import { PostLoginBody } from '@wabinar/api-types/auth';
-import { User } from 'src/types/user';
-import { Workspace } from 'src/types/workspace';
+import { LoginResBody, PostLoginBody } from '@wabinar/api-types/auth';
 
 import { http } from './http';
 import { CREATED, OK } from './http-status';
 
-// TODO: BE API 변경할 때 제거
-type GetUserInfo = {
-  user: User;
-  workspaces: Workspace[];
-};
-
-export const getAuth = async (): Promise<GetUserInfo> => {
+export const getAuth = async (): Promise<LoginResBody> => {
   const res = await http.get(`/auth`);
 
   if (res.status !== OK) throw new Error();
@@ -21,7 +13,7 @@ export const getAuth = async (): Promise<GetUserInfo> => {
 
 export const postAuthLogin = async ({
   code,
-}: PostLoginBody): Promise<GetUserInfo> => {
+}: PostLoginBody): Promise<LoginResBody> => {
   const res = await http.post(`/auth/login`, { code });
 
   if (res.status !== CREATED) throw new Error();

--- a/server/apis/auth/controller.ts
+++ b/server/apis/auth/controller.ts
@@ -1,9 +1,8 @@
 import { CREATED, OK } from '@constants/http-status';
 import jwtAuthenticator from '@middlewares/jwt-authenticator';
-import { PostLoginBody } from '@wabinar/api-types/auth';
+import { LoginResBody, PostLoginBody } from '@wabinar/api-types/auth';
 import asyncWrapper from '@utils/async-wrapper';
 import express, { Request, Response } from 'express';
-import * as userService from '../user/service';
 import * as authService from './service';
 
 interface CookieOptions {
@@ -18,47 +17,44 @@ const router = express.Router();
 router.get(
   '/',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request, res: Response) => {
+  asyncWrapper(async (req: Request, res: Response<LoginResBody>) => {
     if (!req.user) {
       res.status(OK).send({ user: req.user });
       return;
     }
 
-    // req.user가 존재하면 workspaceList를 같이 받아옴
     const { id: userId, name, avatarUrl } = req.user;
-
-    const workspaces = await userService.getWorkspaces(userId);
 
     const user = { id: userId, name, avatarUrl };
 
-    res.status(OK).send({ user, workspaces });
+    res.status(OK).send({ user });
   }),
 );
 
-// authorized된 유저가 아닐 경우(위에서 !req.user조건으로 return 됨)
-// OAuth 페이지에서 workspace로 이동(navigate)하게 되므로
-// 로그인 하여 받아온 유저 정보로 workspace list 정보도 함께 받아온다.
 router.post(
   '/login',
   jwtAuthenticator,
-  asyncWrapper(async (req: Request<{}, {}, PostLoginBody>, res: Response) => {
-    const { code } = req.body;
+  asyncWrapper(
+    async (
+      req: Request<{}, {}, PostLoginBody>,
+      res: Response<LoginResBody>,
+    ) => {
+      const { code } = req.body;
 
-    const { user, loginToken, refreshToken } = await authService.login(code);
+      const { user, loginToken, refreshToken } = await authService.login(code);
 
-    const workspaces = await userService.getWorkspaces(Number(user.id));
+      const cookieOptions: CookieOptions = {
+        httpOnly: true,
+        sameSite: 'lax',
+        maxAge: 1000 * 60 * 60 * 24,
+        signed: true,
+      };
+      res.cookie('accessToken', loginToken, cookieOptions);
+      res.cookie('refreshToken', refreshToken, cookieOptions);
 
-    const cookieOptions: CookieOptions = {
-      httpOnly: true,
-      sameSite: 'lax',
-      maxAge: 1000 * 60 * 60 * 24,
-      signed: true,
-    };
-    res.cookie('accessToken', loginToken, cookieOptions);
-    res.cookie('refreshToken', refreshToken, cookieOptions);
-
-    res.status(CREATED).send({ user, workspaces });
-  }),
+      res.status(CREATED).send({ user });
+    },
+  ),
 );
 
 router.delete(

--- a/server/apis/user/service.test.ts
+++ b/server/apis/user/service.test.ts
@@ -1,7 +1,8 @@
+import ForbiddenError from '@errors/forbidden-error';
+
 const { getWorkspaces } = require('./service');
 const userModel = require('@apis/user/model');
 const workspaceModel = require('@apis/workspace/model');
-const { default: AuthorizationError } = require('@errors/authorization-error');
 
 jest.mock('@apis/user/model', () => {
   return { findOne: jest.fn() };
@@ -24,16 +25,12 @@ describe('getWorkspaces', () => {
     expect(workspaces).toEqual(successfulWorkspaces);
   });
 
-  /*
   it('비정상적인 유저 아이디를 받으면 에러를 던진다.', async () => {
     const user1 = 1;
     const user2 = 2;
 
-    expect(() => getWorkspaces(user1, user2)).rejects.toThrow(
-      AuthorizationError,
-    );
+    expect(() => getWorkspaces(user1, user2)).rejects.toThrow(ForbiddenError);
   });
-  */
 });
 
 export {};

--- a/server/apis/user/service.ts
+++ b/server/apis/user/service.ts
@@ -1,14 +1,12 @@
 import userModel from '@apis/user/model';
 import workspaceModel from '@apis/workspace/model';
+import ERROR_MESSAGE from '@constants/error-message';
+import ForbiddenError from '@errors/forbidden-error';
 
 export const getWorkspaces = async (userId: number, targetUserId?: number) => {
-  /*
   if (targetUserId !== userId) {
-    throw new AuthorizationError(
-      '요청하신 유저 정보와 현재 로그인된 유저 정보가 달라요 ^^',
-    );
+    throw new ForbiddenError(ERROR_MESSAGE.FORBIDDEN_WORKSPACES);
   }
-  */
 
   const user = await userModel.findOne({ id: userId });
 

--- a/server/apis/workspace/controller.ts
+++ b/server/apis/workspace/controller.ts
@@ -43,7 +43,10 @@ router.get(
   asyncWrapper(async (req: Request<GetInfoParams>, res: Response) => {
     const { id: workspaceId } = req.params;
 
-    const workspaceInfo = await workspaceService.info(Number(workspaceId));
+    const workspaceInfo = await workspaceService.info(
+      req.user.id,
+      Number(workspaceId),
+    );
 
     res.status(OK).send(workspaceInfo);
   }),

--- a/server/constants/error-message.ts
+++ b/server/constants/error-message.ts
@@ -2,6 +2,7 @@ const ERROR_MESSAGE = {
   UNAUTHORIZED: '유저 인증 실패',
   UNAUTHORIZED_OAUTH: 'OAuth 유저 인증 실패',
   ACCESS_TOKEN_REQUEST_FAILED: 'access 토큰 요청 실패',
+  FORBIDDEN: '접근 권한이 없으세요 ^^',
 
   FORBIDDEN_WORKSPACES: '요청하신 유저 정보가 로그인 정보와 달라요 ^^',
   ALREADY_JOINED_WORKSPACE: '이미 참여한 워크스페이스',

--- a/server/constants/error-message.ts
+++ b/server/constants/error-message.ts
@@ -3,6 +3,7 @@ const ERROR_MESSAGE = {
   UNAUTHORIZED_OAUTH: 'OAuth 유저 인증 실패',
   ACCESS_TOKEN_REQUEST_FAILED: 'access 토큰 요청 실패',
 
+  FORBIDDEN_WORKSPACES: '요청하신 유저 정보가 로그인 정보와 달라요 ^^',
   ALREADY_JOINED_WORKSPACE: '이미 참여한 워크스페이스',
   INVALID_WORKSPACE: '존재하지 않는 워크스페이스',
 

--- a/server/constants/http-status.ts
+++ b/server/constants/http-status.ts
@@ -3,5 +3,6 @@ export const CREATED = 201;
 
 export const BAD_REQUEST = 400;
 export const UNAUTHORIZED = 401;
+export const FORBIDDEN = 403;
 
 export const INTERNAL_SERVER_ERROR = 500;

--- a/server/errors/forbidden-error.ts
+++ b/server/errors/forbidden-error.ts
@@ -1,0 +1,10 @@
+import CustomError from '.';
+import { FORBIDDEN } from '@constants/http-status';
+
+class ForbiddenError extends CustomError {
+  constructor(message = 'Forbidden') {
+    super(message, FORBIDDEN);
+  }
+}
+
+export default ForbiddenError;


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Resolves #369 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 인증 API에서 workspaces 제거했어요.

- getWorkspaces 주석으로 되어있던 부분 다시 살리고 ForbiddenError 던졌어요.

- 특정 워크스페이스 정보 받아오는 API에도 ForbiddenError 추가했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

테스트가 안돌아가요...

```ts
describe('info', () => {
  const USER_ID = 1;
  const WORKSPACE_ID = 1;
  const INVALID_WORKSPACE_ID = -1;

  it('워크스페이스 ID가 DB에 존재할 경우 조회에 성공한다.', async () => {
    const WORKSPACE_NAME = 'Wab';
    const USER = { id: 1, name: 'name', avatarUrl: 'avatarUrl' };

    workspaceModel.findOne.mockResolvedValueOnce({
      id: WORKSPACE_ID,
      name: WORKSPACE_NAME,
      code: VALID_CODE,
      users: [USER],
      moms: [],
    });

    expect(workspaceService.info(USER_ID, WORKSPACE_ID)).resolves.toEqual({
      name: WORKSPACE_NAME,
      members: [USER],
      moms: [],
    });
  });
```