### PR TITLE
Fix/#375-K: 회의록 블럭 memo 조건 추가

### DIFF
--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -150,7 +150,10 @@ function TextBlock({
   }, []);
 
   useEffect(() => {
+    if (!blockRef.current) return;
+
     registerRef(blockRef);
+    blockRef.current.setAttribute('data-index', index.toString());
   }, [index]);
 
   useEffect(() => {

--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* TextBlock 마운트 이후 항상 존재하는 blockRef.current 존재 여부 확인하는 불필요한 가드를 제거하기 위함 */
+
 import { BlockType } from '@wabinar/constants/block';
 import { BLOCK_EVENT } from '@wabinar/constants/socket-message';
 import {
@@ -56,7 +59,7 @@ function TextBlock({
 
   // 리모트 연산 수행결과로 innerText 변경 시 커서의 위치 조정
   const updateCaretPosition = (updateOffset = 0) => {
-    if (!blockRef.current || offsetRef.current === null) return;
+    if (offsetRef.current === null) return;
 
     const selection = window.getSelection();
 
@@ -67,14 +70,14 @@ function TextBlock({
     const range = new Range();
 
     // 우선 블럭의 첫번째 text node로 고정, text node가 없는 경우 clearOffset()
-    if (!blockRef.current.firstChild) {
+    if (!blockRef.current!.firstChild) {
       clearOffset();
       return;
     }
 
     // range start와 range end가 같은 경우만 가정
     range.setStart(
-      blockRef.current.firstChild,
+      blockRef.current!.firstChild,
       offsetRef.current + updateOffset,
     );
     range.collapse();
@@ -87,9 +90,7 @@ function TextBlock({
   const onInitialize = (crdt: unknown) => {
     syncCRDT(crdt);
 
-    if (!blockRef.current) return;
-
-    blockRef.current.innerText = readCRDT();
+    blockRef.current!.innerText = readCRDT();
 
     updateCaretPosition();
   };
@@ -104,9 +105,7 @@ function TextBlock({
       return;
     }
 
-    if (!blockRef.current) return;
-
-    blockRef.current.innerText = readCRDT();
+    blockRef.current!.innerText = readCRDT();
 
     if (prevIndex === null || offsetRef.current === null) return;
 
@@ -123,9 +122,7 @@ function TextBlock({
       return;
     }
 
-    if (!blockRef.current) return;
-
-    blockRef.current.innerText = readCRDT();
+    blockRef.current!.innerText = readCRDT();
 
     if (targetIndex === null || offsetRef.current === null) return;
 
@@ -150,10 +147,8 @@ function TextBlock({
   }, []);
 
   useEffect(() => {
-    if (!blockRef.current) return;
-
     registerRef(blockRef);
-    blockRef.current.setAttribute('data-index', index.toString());
+    blockRef.current!.setAttribute('data-index', index.toString());
   }, [index]);
 
   useEffect(() => {
@@ -165,10 +160,8 @@ function TextBlock({
       const remoteDeletion = localDeleteCRDT(0);
       socket.emit(BLOCK_EVENT.DELETE_TEXT, id, remoteDeletion);
 
-      if (!blockRef.current) return;
-
-      blockRef.current.innerText = readCRDT();
-      blockRef.current.focus();
+      blockRef.current!.innerText = readCRDT();
+      blockRef.current!.focus();
     }
   }, [type]);
 
@@ -176,9 +169,7 @@ function TextBlock({
   const onInput: React.FormEventHandler = (e) => {
     setOffset();
 
-    if (!blockRef.current) return;
-
-    if (blockRef.current.innerText === '/') {
+    if (blockRef.current!.innerText === '/') {
       setIsOpen(true);
     } else if (isOpen) {
       setIsOpen(false);
@@ -241,14 +232,14 @@ function TextBlock({
     e.preventDefault();
 
     setOffset();
-    if (offsetRef.current === null || !blockRef.current) return;
+    if (offsetRef.current === null) return;
 
     let previousLetterIndex = offsetRef.current - 1;
-    const previousText = blockRef.current.innerText.slice(
+    const previousText = blockRef.current!.innerText.slice(
       0,
       previousLetterIndex + 1,
     );
-    const nextText = blockRef.current.innerText.slice(previousLetterIndex + 1);
+    const nextText = blockRef.current!.innerText.slice(previousLetterIndex + 1);
 
     const pastedText = e.clipboardData.getData('text/plain').replace('\n', '');
     const remoteInsertions = pastedText
@@ -257,7 +248,7 @@ function TextBlock({
 
     socket.emit(BLOCK_EVENT.UPDATE_TEXT, id, remoteInsertions);
 
-    blockRef.current.innerText = previousText + pastedText + nextText;
+    blockRef.current!.innerText = previousText + pastedText + nextText;
     updateCaretPosition(pastedText.length);
   };
 

--- a/client/src/components/Block/TextBlock.tsx
+++ b/client/src/components/Block/TextBlock.tsx
@@ -12,7 +12,7 @@ import { useOffset } from 'src/hooks/useOffset';
 
 import ee from '../Mom/EventEmitter';
 
-interface BlockProps {
+interface TextBlockProps {
   id: string;
   index: number;
   onHandleBlocks: React.KeyboardEventHandler;
@@ -30,7 +30,7 @@ function TextBlock({
   setType,
   isLocalTypeUpdate,
   registerRef,
-}: BlockProps) {
+}: TextBlockProps) {
   const { momSocket: socket } = useSocketContext();
 
   const initBlock = () => {

--- a/client/src/components/Block/index.tsx
+++ b/client/src/components/Block/index.tsx
@@ -98,4 +98,8 @@ function Block({
   );
 }
 
-export default memo(Block);
+function isMemoized(prev: BlockProps, next: BlockProps) {
+  return prev.id === next.id;
+}
+
+export default memo(Block, isMemoized);


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- Resolves #375 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- remote에서 블럭을 추가하거나 삭제하면 내 Caret이 초기화돼서 에디터 사용성이 떨어지는 이슈가 있었어요.

- 처음에 블럭 포커스 잡는 방식이 문제라고 생각했는데 아니더라고요.

  - 블럭 추가/삭제에 포커스 이동하는 작업을 회의록 대신 각각의 블럭이 하도록 변경하려고 시도했는데 그걸로는 해결할 수 없었어요.

  - 생각해보니까 index props가 변하면 블럭이 리렌더 되는게 문제였어요.

    메모를 하긴 하고있었는데, props가 많고 그 중에 index는 회의록에 블럭이 추가, 삭제 될때마다 변하는 값이라 memo 효과가 없었어요.

- id가 같다면 메모된 블럭을 사용하도록 했어요.

- id 조건만 추가했더니 블럭 포커스 이동할 때 사용하는 data-index 값이 고정돼 문제가 됐어요.
    
    index가 변경되면 data-index 어트리뷰트를 바꿔줬어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)