### PR TITLE
Refactor/#386-C: 긴 메소드의 코드를 여러 private 메소드로 분리

### DIFF
--- a/client/src/utils/rtc/index.ts
+++ b/client/src/utils/rtc/index.ts
@@ -7,6 +7,7 @@ type onMediaDisconnectedCb = (socketId: string) => void;
 
 class RTC {
   static BITRATE = Number(env.WEBRTC_VIDEO_BITRATE);
+
   private socket: Socket;
   private iceServerUrls: string[];
   private userMediaStream: MediaStream;
@@ -27,6 +28,28 @@ class RTC {
     this.streams = new Map();
     this.onMediaConnectedCallback = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
     this.onMediaDisconnectedCallback = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+
+    this.socket.on(
+      WORKSPACE_EVENT.RECEIVE_HELLO,
+      this.sendOfferOnHello.bind(this),
+    );
+    this.socket.on(
+      WORKSPACE_EVENT.RECEIVE_OFFER,
+      this.sendAnswerOnOffer.bind(this),
+    );
+    this.socket.on(
+      WORKSPACE_EVENT.RECEIVE_ANSWER,
+      this.setRemotePeerOnAnswer.bind(this),
+    );
+    this.socket.on(WORKSPACE_EVENT.RECEIVE_ICE, this.addIce.bind(this));
+    this.socket.on(
+      WORKSPACE_EVENT.RECEIVE_BYE,
+      this.cleanUpRemoteAndEmitMediaDisconnectedEvent.bind(this),
+    );
+  }
+
+  connect() {
+    this.socket.emit(WORKSPACE_EVENT.SEND_HELLO);
   }
 
   onMediaConnected(callback: onMediaConnectedCb) {
@@ -37,7 +60,61 @@ class RTC {
     this.onMediaDisconnectedCallback = callback;
   }
 
-  #createPeerConnection(remoteSocketId: string) {
+  private async sendOfferOnHello(remoteSocketId: string) {
+    const pc = this.createPeerConnection(remoteSocketId);
+
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+
+    this.socket.emit(WORKSPACE_EVENT.SEND_OFFER, offer, remoteSocketId);
+  }
+
+  private async sendAnswerOnOffer(
+    offer: RTCSessionDescriptionInit,
+    remoteSocketId: string,
+  ) {
+    const pc = this.createPeerConnection(remoteSocketId);
+    await pc.setRemoteDescription(offer);
+
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+
+    this.setVideoBitrate(pc, RTC.BITRATE);
+
+    this.socket.emit(WORKSPACE_EVENT.SEND_ANSWER, answer, remoteSocketId);
+  }
+
+  private async setRemotePeerOnAnswer(
+    answer: RTCSessionDescriptionInit,
+    remoteSocketId: string,
+  ) {
+    const pc = this.connections.get(remoteSocketId);
+    if (!pc) {
+      throw new Error('No RTCPeerConnection on answer received.');
+    }
+
+    await pc.setRemoteDescription(answer);
+
+    this.setVideoBitrate(pc, RTC.BITRATE);
+  }
+
+  private addIce(ice: RTCIceCandidateInit, remoteSocketId: string) {
+    const pc = this.connections.get(remoteSocketId);
+    if (!pc) {
+      throw new Error('No RTCPeerConnection on ice candindate received.');
+    }
+
+    pc.addIceCandidate(ice);
+  }
+
+  private cleanUpRemoteAndEmitMediaDisconnectedEvent(remoteSocketId: string) {
+    this.connections.delete(remoteSocketId);
+    this.streams.delete(remoteSocketId);
+
+    this.onMediaDisconnectedCallback(remoteSocketId);
+  }
+
+  private createPeerConnection(remoteSocketId: string) {
     // initialize
     const pcOptions = {
       iceServers: [{ urls: this.iceServerUrls }],
@@ -45,33 +122,48 @@ class RTC {
     const pc = new RTCPeerConnection(pcOptions);
 
     // add event listeners
-    pc.addEventListener('icecandidate', (iceEvent) => {
-      this.socket.emit(
-        WORKSPACE_EVENT.SEND_ICE,
-        iceEvent.candidate,
-        remoteSocketId,
-      );
-    });
-    pc.addEventListener('track', async (event) => {
-      if (this.streams.has(remoteSocketId)) {
-        return;
-      }
+    const emitIce: (iceEvent: RTCPeerConnectionIceEvent) => void =
+      this.emitIce.bind(this, remoteSocketId);
+    pc.addEventListener('icecandidate', emitIce);
 
-      const [remoteStream] = event.streams;
-
-      this.streams.set(remoteSocketId, remoteStream);
-      this.onMediaConnectedCallback(remoteSocketId, remoteStream);
-    });
+    const setRemoteTrack: (trackEvent: RTCTrackEvent) => void =
+      this.setRemoteTrackAndEmitMediaConnectedEvent.bind(this, remoteSocketId);
+    pc.addEventListener('track', setRemoteTrack);
 
     // add tracks
     this.userMediaStream
       .getTracks()
       .forEach((track) => pc.addTrack(track, this.userMediaStream));
 
+    // register connection
+    this.connections.set(remoteSocketId, pc);
+
     return pc;
   }
 
-  async #setVideoBitrate(pc: RTCPeerConnection, bitrate: number) {
+  private emitIce(remoteSocketId: string, iceEvent: RTCPeerConnectionIceEvent) {
+    this.socket.emit(
+      WORKSPACE_EVENT.SEND_ICE,
+      iceEvent.candidate,
+      remoteSocketId,
+    );
+  }
+
+  private setRemoteTrackAndEmitMediaConnectedEvent(
+    remoteSocketId: string,
+    trackEvent: RTCTrackEvent,
+  ) {
+    if (this.streams.has(remoteSocketId)) {
+      return;
+    }
+
+    const [remoteStream] = trackEvent.streams;
+
+    this.streams.set(remoteSocketId, remoteStream);
+    this.onMediaConnectedCallback(remoteSocketId, remoteStream);
+  }
+
+  private async setVideoBitrate(pc: RTCPeerConnection, bitrate: number) {
     // fetch video sender
     const videoSender = pc
       .getSenders()
@@ -85,72 +177,6 @@ class RTC {
     const params = videoSender.getParameters();
     params.encodings[0].maxBitrate = bitrate;
     await videoSender.setParameters(params);
-  }
-
-  connect() {
-    this.socket.on(WORKSPACE_EVENT.RECEIVE_HELLO, async (remoteSocketId) => {
-      const pc = this.#createPeerConnection(remoteSocketId);
-      this.connections.set(remoteSocketId, pc);
-
-      const offer = await pc.createOffer();
-      await pc.setLocalDescription(offer);
-
-      this.socket.emit(
-        WORKSPACE_EVENT.SEND_OFFER,
-        pc.localDescription,
-        remoteSocketId,
-      );
-    });
-
-    this.socket.on(
-      WORKSPACE_EVENT.RECEIVE_OFFER,
-      async (offer, remoteSocketId) => {
-        const pc = this.#createPeerConnection(remoteSocketId);
-        this.connections.set(remoteSocketId, pc);
-
-        await pc.setRemoteDescription(offer);
-
-        const answer = await pc.createAnswer();
-        await pc.setLocalDescription(answer);
-
-        this.#setVideoBitrate(pc, RTC.BITRATE);
-
-        this.socket.emit(WORKSPACE_EVENT.SEND_ANSWER, answer, remoteSocketId);
-      },
-    );
-
-    this.socket.on(
-      WORKSPACE_EVENT.RECEIVE_ANSWER,
-      async (answer, remoteSocketId) => {
-        const pc = this.connections.get(remoteSocketId);
-        if (!pc) {
-          throw new Error('No RTCPeerConnection on answer received.');
-        }
-
-        await pc.setRemoteDescription(answer);
-
-        this.#setVideoBitrate(pc, RTC.BITRATE);
-      },
-    );
-
-    this.socket.on(WORKSPACE_EVENT.RECEIVE_ICE, (ice, remoteSocketId) => {
-      const pc = this.connections.get(remoteSocketId);
-
-      if (!pc) {
-        throw new Error('No RTCPeerConnection on ice candindate received.');
-      }
-
-      pc.addIceCandidate(ice);
-    });
-
-    this.socket.on(WORKSPACE_EVENT.RECEIVE_BYE, (remoteSocketId) => {
-      this.connections.delete(remoteSocketId);
-      this.streams.delete(remoteSocketId);
-
-      this.onMediaDisconnectedCallback(remoteSocketId);
-    });
-
-    this.socket.emit(WORKSPACE_EVENT.SEND_HELLO);
   }
 }
 


### PR DESCRIPTION
## 🤠 개요

- resolves #386

## 💫 설명

1. 긴 메소드의 코드를 여러 private 메소드로 분리합니다.
    - `connect()`
    - `createPeerConnection()`

1. `connect()`에 있던 socket event listening 로직을 constructor로 옮깁니다.

1. `#` 대신 `private` 제한자를 씁니다.

1. 이제 저번처럼 ice 교환시 오류는 나타나지 않아요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)