### PR TITLE
Perf/#388-B: MomList isMemoized 함수 추가

### DIFF
--- a/client/src/components/Sidebar/MomList.tsx
+++ b/client/src/components/Sidebar/MomList.tsx
@@ -88,4 +88,8 @@ function MomList({ moms, selectedMom, setSelectedMom }: MomListProps) {
   );
 }
 
-export default memo(MomList);
+const isMemoized = (prevProps: MomListProps, nextProps: MomListProps) => {
+  return prevProps.moms === nextProps.moms;
+};
+
+export default memo(MomList, isMemoized);


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- resolve: #388

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- #373 이후로 다시 momlist가 리렌더링이 되고 있어요.
- 그래서 props로 전달받은 moms가 바뀔 때만 리렌더링 할 수 있게 isMemoized 함수를 추가했어요.

## 🌜 고민거리 (Optional)

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)


https://user-images.githubusercontent.com/65100540/207810273-b312ad24-85bb-455c-ac02-deafa8809043.mov

