### PR TITLE
Hotfix: 6주차 배포 추가 수정

### DIFF
--- a/client/src/components/Mom/index.tsx
+++ b/client/src/components/Mom/index.tsx
@@ -255,7 +255,7 @@ function Mom() {
     return <div className={style['mom-container']}></div>;
   }
 
-  if (isMomsEmpty) {
+  if (isMomsEmpty && !selectedMom) {
     return <DefaultMom />;
   }
 

--- a/client/src/pages/Workspace/index.tsx
+++ b/client/src/pages/Workspace/index.tsx
@@ -7,10 +7,10 @@ import WorkspacesContext from 'src/contexts/workspaces';
 import useUserContext from 'src/hooks/context/useUserContext';
 import { Workspace as TWorkspace } from 'src/types/workspace';
 
-function WorkspacePage() {
-  const Layout = lazy(() => import('./Layout'));
-  const Workspace = lazy(() => import('components/Workspace'));
+const Layout = lazy(() => import('./Layout'));
+const Workspace = lazy(() => import('components/Workspace'));
 
+function WorkspacePage() {
   const { user } = useUserContext();
 
   const params = useParams();


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #385 이후에 워크스페이스를 생성하고 회의록을 만들어 선택했을 때 Mom이 바뀌지 않는 사이드 이펙트를 발견했어요.

  - 회의록이 아무것도 없거나 selectedMom이 없을 때 Default UI를 보여주게 변경했습니다.

- 모듈 lazy load가 함수형 컴포넌트 내부에서 이루어지고 있었어요.

  - 밖으로 이동했습니다.

