### PR TITLE
Refactor/#414-B: query 중복 코드 useWorkspaceQuery 적용

### DIFF
--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { getWorkspaceInfo } from 'src/apis/workspace';
+import { useWorkspaceQuery } from 'src/queries/useWorkspaceQuery';
 
 import Header from './Header';
 import MeetingButton from './MeetingButton';
@@ -10,10 +9,7 @@ import style from './style.module.scss';
 
 function Sidebar() {
   const { id } = useParams();
-  const { data: workspace } = useQuery({
-    queryKey: ['workspace', id],
-    queryFn: () => getWorkspaceInfo({ id }),
-  });
+  const { data: workspace } = useWorkspaceQuery(id);
 
   if (!workspace) {
     return <div className={style['sidebar-container']}></div>;

--- a/client/src/components/Workspace/index.tsx
+++ b/client/src/components/Workspace/index.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import * as MomMessage from '@wabinar/api-types/mom';
 import { MOM_EVENT, WORKSPACE_EVENT } from '@wabinar/constants/socket-message';
 import Mom from 'components/Mom';
@@ -6,12 +5,12 @@ import DefaultMom from 'components/Mom/DefaultMom';
 import Sidebar from 'components/Sidebar';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { getWorkspaceInfo } from 'src/apis/workspace';
 import MeetingMediaBar from 'src/components/MeetingMediaBar';
 import MeetingContext from 'src/contexts/meeting';
 import { SelectedMomContext } from 'src/contexts/selected-mom';
 import { SocketContext } from 'src/contexts/socket';
 import useSocket from 'src/hooks/useSocket';
+import { useWorkspaceQuery } from 'src/queries/useWorkspaceQuery';
 import { TMom } from 'src/types/mom';
 
 function Workspace() {
@@ -21,10 +20,7 @@ function Workspace() {
   const params = useParams();
   const momId = params['*'];
 
-  const { data: workspace } = useQuery({
-    queryKey: ['workspace', id],
-    queryFn: () => getWorkspaceInfo({ id }),
-  });
+  const { data: workspace } = useWorkspaceQuery(id);
 
   const [selectedMom, setSelectedMom] = useState<TMom | null>(null);
   const [isOnGoing, setIsOnGoing] = useState(false);

--- a/client/src/queries/useWorkspaceQuery.tsx
+++ b/client/src/queries/useWorkspaceQuery.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { getWorkspaceInfo } from 'src/apis/workspace';
+
+export function useWorkspaceQuery(id?: string) {
+  return useQuery({
+    queryKey: ['workspace', id],
+    queryFn: () => getWorkspaceInfo({ id }),
+  });
+}


### PR DESCRIPTION
## 🤠 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- close: #414 

## 💫 설명

<!-- 

- 현재 Pr 설명 

-->

- 같은 query 로직이 흩어져 있을 때 이런 문제가 발생할 수 있어요!
  - `queryKey`를 잘못 쓸 수 있음
  - `queryFn`을 잘못 쓸 수 있음

- 따라서 해당 로직을 `useWorkspaceQuery` 훅에서 관리해 똑같은 동작을 보장해요.

<br />

- [`client/src/pages/Workspace/index.tsx`](https://github.com/boostcampwm-2022/web27-Wabinar/blob/dev/client/src/pages/Workspace/index.tsx) 여기도 `getWorkspace`를 호출하고 있더라구요
  - 간단해 보이지 않아서 새로 이슈 만들어서 작업 진행할게요~

## 🌜 고민거리 (Optional) 

### Q. 테스트코드 써볼까요?
- 지금은 정말 간단한 리팩토링이어서 괜찮은데 [`client/src/pages/Workspace/index.tsx`](https://github.com/boostcampwm-2022/web27-Wabinar/blob/dev/client/src/pages/Workspace/index.tsx)같이 로직이 좀 있는 걸 고치려면 테스트 코드가 있어야 할 것 같아요.
  - 가령 이 코드 같은 경우에 각 case에 맞게 잘 navigate되는지 테스트코드 작성해두고 리팩토링 진행하면 좋을 것 같아요.
  ```tsx
  const loadWorkspaces = async () => {
    if (!user) {
      navigate('/');
      return;
    }

    const { id: userId } = user;
  
    const { workspaces: userWorkspaces } = await getWorkspaces({
      id: userId,
    });

    setIsLoaded(true);
    setWorkspaces(userWorkspaces);

    if (!userWorkspaces.length) {
      navigate('/workspace');
      return;
    }

    if (params['*']?.length) return;

    const defaultWorkspace = userWorkspaces[0];
    const { id: workspaceId } = defaultWorkspace;

    navigate(`/workspace/${workspaceId}`);
  };
  ```

<!-- 

### Q. 고민1
뭐시기 뭐시기 

-->

## 📷 스크린샷 (Optional)